### PR TITLE
💬Change Default Value Serialization Behaviour: Omit Every Default Value except for Bools and Numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,18 @@ go get github.com/hochfrequenz/go-bo4e
 
 ## Version Notes
 
+### General Default Value Marshalling Behaviour since v0.0.22
+
+Since v0.0.22 default values are no longer marshalled/included in serialized Business Objects or COMponents.
+Before v0.0.22 default values of required fields serialized as f.e. empty string, `null` or empty slice.
+For enums this behaviour had already been introduced in v0.0.19 (see below).
+This is a step towards decoupling of serialization and validation.
+
 ### Default Enum Marshalling Behaviour since v0.0.19
 
 Since version v0.0.19 default enum values are no longer serialized/marshalled.
 Prior to v0.0.19 fields with an enum type that are required but were uninitialized had been serialized as `NameOfEnum(0)`.
-This change leads to a complete decoupling of serialization and validation.
+This change is a step towards decoupling of serialization and validation.
 
 ### Breaking Changes introduced in v0.0.13 and v0.0.14:
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ go get github.com/hochfrequenz/go-bo4e
 ### General Default Value Marshalling Behaviour since v0.0.22
 
 Since v0.0.22 default values are no longer marshalled/included in serialized Business Objects or COMponents.
-Before v0.0.22 default values of required fields serialized as f.e. empty string, `null` or empty slice.
+Prior to v0.0.22 default values of required fields serialized as f.e. empty string, `null` or empty slice.
 For enums this behaviour had already been introduced in v0.0.19 (see below).
 This is a step towards decoupling of serialization and validation.
 

--- a/bo/bilanzierung.go
+++ b/bo/bilanzierung.go
@@ -21,7 +21,7 @@ type Bilanzierung struct {
 	Lastprofile              []com.Lastprofil `json:"lastprofile,omitempty"`                                                         // Lastprofile ist eine Liste der verwendeten Lastprofile (SLP, SLP/TLP, ALP etc.)
 	Bilanzierungsbeginn      time.Time        `json:"bilanzierungsbeginn,omitempty" validate:"omitempty,ltefield=Bilanzierungsende"` // Bilanzierungsbeginn ist der inklusive Beginn der Bilanzierung
 	Bilanzierungsende        time.Time        `json:"bilanzierungsende,omitempty" validate:"omitempty,gtefield=Bilanzierungsbeginn"` // Bilanzierungsende ist das exklusive Ende der Bilanzierung
-	Bilanzkreis              string           `json:"bilanzkreis" validate:"omitempty,len=16,eic"`                                   // Bilanzkreis ist der EIC-Code des Bilanzkreises
+	Bilanzkreis              string           `json:"bilanzkreis,omitempty" validate:"omitempty,len=16,eic"`                         // Bilanzkreis ist der EIC-Code des Bilanzkreises
 	Jahresverbrauchsprognose *com.Menge       `json:"jahresverbrauchsprognose,omitempty"`                                            // Jahresverbrauchsprognose ist die Jahresverbrauchsprognose
 	Kundenwert               *com.Menge       `json:"kundenwert,omitempty"`                                                          // Kundenwert ist der Kundenwert
 	// Verbrauchsaufteilung beschreibt, welcher Anteil im SLP- bzw. TLP-Profil steckt

--- a/bo/businessobject.go
+++ b/bo/businessobject.go
@@ -17,7 +17,7 @@ type BusinessObject interface {
 type Geschaeftsobjekt struct {
 	BoTyp             botyp.BOTyp           `json:"boTyp" validate:"required"`           // BoTyp is the type of business object, may be used as discriminator
 	VersionStruktur   string                `json:"versionStruktur" validate:"required"` // VersionStruktur is the version of BO4E used
-	ExterneReferenzen []com.ExterneReferenz `json:"externeReferenzen"`                   // ExterneReferenzen are external references of this object in various systems
+	ExterneReferenzen []com.ExterneReferenz `json:"externeReferenzen,omitempty"`         // ExterneReferenzen are external references of this object in various systems
 }
 
 func (gob Geschaeftsobjekt) GetBoTyp() botyp.BOTyp {

--- a/bo/energiemenge.go
+++ b/bo/energiemenge.go
@@ -8,7 +8,7 @@ import (
 // Energiemenge contains information about consumption at a location
 type Energiemenge struct {
 	Geschaeftsobjekt
-	LokationsId  string                    `json:"lokationsId" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
-	LokationsTyp lokationstyp.Lokationstyp `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                          // LokationsTyp is the type of the location in LokationsId
-	Verbrauch    []com.Verbrauch           `json:"energieverbrauch" validate:"required,min=1"`                                                         // Verbrauch are consumption data
+	LokationsId  string                    `json:"lokationsId,omitempty" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
+	LokationsTyp lokationstyp.Lokationstyp `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                                    // LokationsTyp is the type of the location in LokationsId
+	Verbrauch    []com.Verbrauch           `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Verbrauch are consumption data
 }

--- a/bo/geschaeftspartner.go
+++ b/bo/geschaeftspartner.go
@@ -11,7 +11,7 @@ import (
 type Geschaeftspartner struct {
 	Geschaeftsobjekt
 	Anrede                  anrede.Anrede                                   `json:"anrede,omitempty"`                                                               // Die Anrede für den Geschaeftspartner, Z.B. HERR
-	Name1                   string                                          `json:"name1" validate:"required" example:"Yellow Strom GmbH,Hagen"`                    // Name1 ist der erste Teil des Namens. Hier kann der Firmenname oder bei Privatpersonen beispielsweise der Nachname dargestellt werden.
+	Name1                   string                                          `json:"name1,omitempty" validate:"required" example:"Yellow Strom GmbH,Hagen"`          // Name1 ist der erste Teil des Namens. Hier kann der Firmenname oder bei Privatpersonen beispielsweise der Nachname dargestellt werden.
 	Name2                   string                                          `json:"name2,omitempty" example:"'Bereich Süd','Nina'"`                                 // Name2 ist der zweite Teil des Namens. Hier kann der eine Erweiterung zum Firmennamen oder bei Privatpersonen beispielsweise der Vorname dargestellt werden.
 	Name3                   string                                          `json:"name3,omitempty" example:"Afrika,Sängerin"`                                      // Name3 enthält weitere Ergänzungen zum Firmennamen oder bei Privatpersonen Zusätze zum Namen dargestellt werden
 	Gewerbekennzeichnung    bool                                            `json:"gewerbekennzeichnung" validate:"omitempty,required"`                             // Gewerbekennzeichnung markiert, ob es sich um einen Gewerbe/Unternehmen (true) oder eine Privatperson handelt (false)
@@ -22,6 +22,6 @@ type Geschaeftspartner struct {
 	GlaeubigerId            string                                          `json:"glaeubigerId,omitempty" example:"DE 47116789"`                                   // GlaeubigerId ist die Gläubiger-ID, welche im Zahlungsverkehr verwendet wird
 	EMailAdresse            string                                          `json:"eMailAdresse,omitempty" validate:"omitempty,email" example:"info@mp-energie.de"` // EMailAdresse ist die E-Mail-Adresse des Ansprechpartners
 	Website                 string                                          `json:"website,omitempty" validate:"omitempty,url" example:"https://www.mp-energie.de"` // Website ist die Internetseite des Marktpartners
-	Geschaeftspartnerrollen []geschaeftspartnerrolle.Geschaeftspartnerrolle `json:"geschaeftspartnerrollen" validate:"required,min=1"`                              // Geschaeftspartnerrollen sind die Rollen, die der Geschäftspartner hat
-	Partneradresse          com.Adresse                                     `json:"partneradresse" validate:"required"`                                             // Partneradresse ist die Adresse des Geschäftspartners, an der sich der Hauptsitz befindet.
+	Geschaeftspartnerrollen []geschaeftspartnerrolle.Geschaeftspartnerrolle `json:"geschaeftspartnerrollen,omitempty" validate:"required,min=1"`                    // Geschaeftspartnerrollen sind die Rollen, die der Geschäftspartner hat
+	Partneradresse          com.Adresse                                     `json:"partneradresse,omitempty" validate:"required"`                                   // Partneradresse ist die Adresse des Geschäftspartners, an der sich der Hauptsitz befindet.
 }

--- a/bo/lastgang.go
+++ b/bo/lastgang.go
@@ -10,11 +10,11 @@ import (
 // Lastgang ist ein Modell zur Abbildung eines Lastganges. In diesem Modell werden die Messwerte mit einem vollständigen Zeitintervall angegeben und es bietet daher eine hohe Flexibilität in der Übertragung jeglicher zeitlich veränderlicher Messgrössen.
 type Lastgang struct {
 	Geschaeftsobjekt
-	Sparte       sparte.Sparte               `json:"sparte,omitempty" example:"STROM" validate:"required"`                                               // Sparte ist eine Angabe, ob es sich um einen GAS- oder STROM-Lastgang handelt
-	Version      string                      `json:"version,omitempty" validate:"alphanum"`                                                              // Version ist die Versionsnummer des Lastgangs
-	LokationsId  string                      `json:"lokationsId" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
-	LokationsTyp lokationstyp.Lokationstyp   `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                          // LokationsTyp is the type of the location in LokationsId
-	Messgroesse  mengeneinheit.Mengeneinheit `json:"einheit,omitempty" validate:"required" example:"KWH"`                                                // Messgroesse ist die Definition der gemessenen Größe anhand ihrer Einheit.
-	Obiskennzahl string                      `json:"obiskennzahl,omitempty" example:"1-0:1.8.1"`                                                         // Obiskennzahl ist die genormte OBIS-Kennzahl zur Kennzeichnung der Messgröße
-	Werte        []com.Zeitreihenwert        `json:"energieverbrauch" validate:"required,min=1"`                                                         // Werte sind die im Lastgang enthaltenen Messwerte.
+	Sparte       sparte.Sparte               `json:"sparte,omitempty" example:"STROM" validate:"required"`                                                         // Sparte ist eine Angabe, ob es sich um einen GAS- oder STROM-Lastgang handelt
+	Version      string                      `json:"version,omitempty" validate:"alphanum"`                                                                        // Version ist die Versionsnummer des Lastgangs
+	LokationsId  string                      `json:"lokationsId,omitempty" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
+	LokationsTyp lokationstyp.Lokationstyp   `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                                    // LokationsTyp is the type of the location in LokationsId
+	Messgroesse  mengeneinheit.Mengeneinheit `json:"einheit,omitempty" validate:"required" example:"KWH"`                                                          // Messgroesse ist die Definition der gemessenen Größe anhand ihrer Einheit.
+	Obiskennzahl string                      `json:"obiskennzahl,omitempty" example:"1-0:1.8.1"`                                                                   // Obiskennzahl ist die genormte OBIS-Kennzahl zur Kennzeichnung der Messgröße
+	Werte        []com.Zeitreihenwert        `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Werte sind die im Lastgang enthaltenen Messwerte.
 }

--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -16,25 +16,25 @@ import (
 // Marktlokation contains information about a market location aka "MaLo"
 type Marktlokation struct {
 	Geschaeftsobjekt
-	MarktlokationsId     string                                    `json:"marktlokationsId" example:"12345678913" validate:"required,numeric,len=11,maloid"` // MarktlokationsId is the ID of the market location
-	Sparte               sparte.Sparte                             `json:"sparte,omitempty" validate:"required"`                                             // Sparte describes the Division
-	Energierichtung      energierichtung.Energierichtung           `json:"energierichtung,omitempty" validate:"required"`                                    // Energierichtung describes whether energy is supplied out of or fed into the grid.
-	Bilanzierungsmethode bilanzierungsmethode.Bilanzierungsmethode `json:"bilanzierungsmethode,omitempty" validate:"required"`                               // Bilanzierungsmethode is the accounting method
-	Verbrauchsart        verbrauchsart.Verbrauchsart               `json:"verbrauchsart,omitempty"`                                                          // Verbrauchsart is the consumption type
-	Unterbrechbar        *bool                                     `json:"unterbrechbar,omitempty"`                                                          // Unterbrechbar describes whether the supply is interruptible
-	Netzebene            netzebene.Netzebene                       `json:"netzebene,omitempty" validate:"required"`                                          // Netzebene, in der der Bezug der Energie erfolgt. Bei Strom Spannungsebene der Lieferung, bei Gas Druckstufe.
-	Netzbetreibercodenr  string                                    `json:"netzbetreibercodenr,omitempty" validate:"omitempty,numeric,len=13"`                // Netzbetreibercodenr is the code number of the "Netzbetreiber"
-	Gebiettyp            gebiettyp.Gebiettyp                       `json:"gebiettyp,omitempty"`                                                              // Gebiettyp is the type of the "Netzgebiet"
-	Netzgebietnr         string                                    `json:"netzgebietnr,omitempty"`                                                           // Netzgebietnr is the number of the "Netzgebiet" in the enet database
-	Bilanzierungsgebiet  string                                    `json:"bilanzierungsgebiet,omitempty"`                                                    // Bilanzierungsgebiet, dem das Netzgebiet zugeordnet ist - im Falle eines Strom Netzes.
-	Grundversorgercodenr string                                    `json:"grundversorgercodenr,omitempty" validate:"omitempty,numeric,len=13"`               // Grundversorgercodenr is the code number of the "Grundversorger" responsible for this market location
-	Gasqualitaet         gasqualitaet.Gasqualitaet                 `json:"gasqualitaet,omitempty"`                                                           // Gasqualitaet is the gas quality
-	Endkunde             *Geschaeftspartner                        `json:"endkunde,omitempty" validate:"-"`                                                  // Endkunde is the Geschaeftspartner who owns this market location
+	MarktlokationsId     string                                    `json:"marktlokationsId,omitempty" example:"12345678913" validate:"required,numeric,len=11,maloid"` // MarktlokationsId is the ID of the market location
+	Sparte               sparte.Sparte                             `json:"sparte,omitempty" validate:"required"`                                                       // Sparte describes the Division
+	Energierichtung      energierichtung.Energierichtung           `json:"energierichtung,omitempty" validate:"required"`                                              // Energierichtung describes whether energy is supplied out of or fed into the grid.
+	Bilanzierungsmethode bilanzierungsmethode.Bilanzierungsmethode `json:"bilanzierungsmethode,omitempty" validate:"required"`                                         // Bilanzierungsmethode is the accounting method
+	Verbrauchsart        verbrauchsart.Verbrauchsart               `json:"verbrauchsart,omitempty"`                                                                    // Verbrauchsart is the consumption type
+	Unterbrechbar        *bool                                     `json:"unterbrechbar,omitempty"`                                                                    // Unterbrechbar describes whether the supply is interruptible
+	Netzebene            netzebene.Netzebene                       `json:"netzebene,omitempty" validate:"required"`                                                    // Netzebene, in der der Bezug der Energie erfolgt. Bei Strom Spannungsebene der Lieferung, bei Gas Druckstufe.
+	Netzbetreibercodenr  string                                    `json:"netzbetreibercodenr,omitempty" validate:"omitempty,numeric,len=13"`                          // Netzbetreibercodenr is the code number of the "Netzbetreiber"
+	Gebiettyp            gebiettyp.Gebiettyp                       `json:"gebiettyp,omitempty"`                                                                        // Gebiettyp is the type of the "Netzgebiet"
+	Netzgebietnr         string                                    `json:"netzgebietnr,omitempty"`                                                                     // Netzgebietnr is the number of the "Netzgebiet" in the enet database
+	Bilanzierungsgebiet  string                                    `json:"bilanzierungsgebiet,omitempty"`                                                              // Bilanzierungsgebiet, dem das Netzgebiet zugeordnet ist - im Falle eines Strom Netzes.
+	Grundversorgercodenr string                                    `json:"grundversorgercodenr,omitempty" validate:"omitempty,numeric,len=13"`                         // Grundversorgercodenr is the code number of the "Grundversorger" responsible for this market location
+	Gasqualitaet         gasqualitaet.Gasqualitaet                 `json:"gasqualitaet,omitempty"`                                                                     // Gasqualitaet is the gas quality
+	Endkunde             *Geschaeftspartner                        `json:"endkunde,omitempty" validate:"-"`                                                            // Endkunde is the Geschaeftspartner who owns this market location
 	// only one of the following three optional address attributes can be set
-	Lokationsadresse          *com.Adresse                 `json:"lokationsadresse" validate:"required_without_all=Geoadresse Katasterinformation"` // Lokationsadresse is the address at which the energy supply or feed-in takes place
-	Geoadresse                *com.Geokoordinaten          `json:"geoadresse" validate:"required_without_all=Lokationsadresse Katasterinformation"` // Geoadresse are the gps coordinates
-	Katasterinformation       *com.Katasteradresse         `json:"katasterinformation" validate:"required_without_all=Lokationsadresse Geoadresse"` // Katasterinformation is the Cadastre address
-	ZugehoerigeMesslokationen []com.Messlokationszuordnung `json:"zugehoerigemesslokationen,omitempty"`                                             // ZugehoerigeMesslokationen is a list of MeLos belonging to this market location
+	Lokationsadresse          *com.Adresse                 `json:"lokationsadresse,omitempty" validate:"required_without_all=Geoadresse Katasterinformation"` // Lokationsadresse is the address at which the energy supply or feed-in takes place
+	Geoadresse                *com.Geokoordinaten          `json:"geoadresse,omitempty" validate:"required_without_all=Lokationsadresse Katasterinformation"` // Geoadresse are the gps coordinates
+	Katasterinformation       *com.Katasteradresse         `json:"katasterinformation,omitempty" validate:"required_without_all=Lokationsadresse Geoadresse"` // Katasterinformation is the Cadastre address
+	ZugehoerigeMesslokationen []com.Messlokationszuordnung `json:"zugehoerigemesslokationen,omitempty"`                                                       // ZugehoerigeMesslokationen is a list of MeLos belonging to this market location
 }
 
 var elevenDigitsRegex = regexp.MustCompile(`^[1-9]\d{10}$`)

--- a/bo/marktteilnehmer.go
+++ b/bo/marktteilnehmer.go
@@ -8,8 +8,8 @@ import (
 // Marktteilnehmer models participants of the German energy market
 type Marktteilnehmer struct {
 	Geschaeftspartner
-	Marktrolle       marktrolle.Marktrolle       `json:"marktrolle,omitempty" validate:"required"`                   // Marktrolle gibt im Klartext die Bezeichnung der Marktrolle an. Details siehe ENUM Marktrolle
-	Rollencodenummer string                      `json:"rollencodenummer" validate:"required,numeric,min=13,max=13"` // Rollencodenummer gibt die Codenummer der Marktrolle an (13 digits)
-	Rollencodetyp    rollencodetyp.Rollencodetyp `json:"rollencodetyp,omitempty" validate:"required"`                // Rollencodetyp gibt den Typ des Codes an/Vergabestelle. Details siehe ENUM Rollencodetyp
-	Makoadresse      string                      `json:"makoadresse,omitempty" validate:"omitempty"`                 // Makoadresse ist die 1:1-Kommunikationsadresse des Marktteilnehmers. Diese wird in der Marktkommunikation verwendet.
+	Marktrolle       marktrolle.Marktrolle       `json:"marktrolle,omitempty" validate:"required"`                             // Marktrolle gibt im Klartext die Bezeichnung der Marktrolle an. Details siehe ENUM Marktrolle
+	Rollencodenummer string                      `json:"rollencodenummer,omitempty" validate:"required,numeric,min=13,max=13"` // Rollencodenummer gibt die Codenummer der Marktrolle an (13 digits)
+	Rollencodetyp    rollencodetyp.Rollencodetyp `json:"rollencodetyp,omitempty" validate:"required"`                          // Rollencodetyp gibt den Typ des Codes an/Vergabestelle. Details siehe ENUM Rollencodetyp
+	Makoadresse      string                      `json:"makoadresse,omitempty" validate:"omitempty"`                           // Makoadresse ist die 1:1-Kommunikationsadresse des Marktteilnehmers. Diese wird in der Marktkommunikation verwendet.
 }

--- a/bo/messlokation.go
+++ b/bo/messlokation.go
@@ -10,15 +10,15 @@ import (
 // Messlokation contains information about a metering location aka "MeLo"
 type Messlokation struct {
 	Geschaeftsobjekt
-	MesslokationsId              string              `json:"messlokationsId" example:"DE0123456789012345678901234567890" validate:"alphanum,required,len=33"` // MesslokationsId is the ID of the metering location
-	Sparte                       sparte.Sparte       `json:"sparte,omitempty" validate:"required"`                                                            // Sparte is the division
-	NetzebeneMessung             netzebene.Netzebene `json:"netzebeneMessung,omitempty"`                                                                      // NetzebeneMessung is the grid level of measurement
-	MessgebietNr                 string              `json:"messgebietNr,omitempty"`                                                                          // MessgebietNr is the number of the measurement area in ene't database
-	Geraete                      []com.Hardware      `json:"geraete,omitempty"`                                                                               // Geraete is a list of devices
-	Messdienstleistung           *com.Dienstleistung `json:"messdienstleistung,omitempty"`                                                                    // Messdienstleistung is a metering services
-	GrundzustaendigerMsbCodeNr   string              `json:"grundzustaendigerMSBCodeNr,omitempty" validate:"omitempty,numeric,len=13"`                        // GrundzustaendigerMsbCodeNr is the code number of the "grundzuständige Messstellenbetreiber", responsitble for this MeLo
-	GrundzustaendigerMsbImCodeNr string              `json:"GrundzustaendigerMsbImCodeNr,omitempty" validate:"omitempty,numeric,len=13"`                      // GrundzustaendigerMsbImCodeNr si the code number of the "grundzuständige Messsstellenbetreiber", responsible for intelligent meters at this MeLo
-	Messlokationszaehler         []Zaehler           `json:"messlokationszaehler,omitempty"`                                                                  // Messlokationszaehler meters associated to this Messlokation
+	MesslokationsId              string              `json:"messlokationsId,omitempty" example:"DE0123456789012345678901234567890" validate:"alphanum,required,len=33"` // MesslokationsId is the ID of the metering location
+	Sparte                       sparte.Sparte       `json:"sparte,omitempty" validate:"required"`                                                                      // Sparte is the division
+	NetzebeneMessung             netzebene.Netzebene `json:"netzebeneMessung,omitempty"`                                                                                // NetzebeneMessung is the grid level of measurement
+	MessgebietNr                 string              `json:"messgebietNr,omitempty"`                                                                                    // MessgebietNr is the number of the measurement area in ene't database
+	Geraete                      []com.Hardware      `json:"geraete,omitempty"`                                                                                         // Geraete is a list of devices
+	Messdienstleistung           *com.Dienstleistung `json:"messdienstleistung,omitempty"`                                                                              // Messdienstleistung is a metering services
+	GrundzustaendigerMsbCodeNr   string              `json:"grundzustaendigerMSBCodeNr,omitempty" validate:"omitempty,numeric,len=13"`                                  // GrundzustaendigerMsbCodeNr is the code number of the "grundzuständige Messstellenbetreiber", responsitble for this MeLo
+	GrundzustaendigerMsbImCodeNr string              `json:"GrundzustaendigerMsbImCodeNr,omitempty" validate:"omitempty,numeric,len=13"`                                // GrundzustaendigerMsbImCodeNr si the code number of the "grundzuständige Messsstellenbetreiber", responsible for intelligent meters at this MeLo
+	Messlokationszaehler         []Zaehler           `json:"messlokationszaehler,omitempty"`                                                                            // Messlokationszaehler meters associated to this Messlokation
 	// only one of the following three optional address attributes can be set
 	Messadresse         *com.Adresse         `json:"messadresse" validate:"required_without_all=Geoadresse Katasterinformation"` // Messadresse is a street address of the Messlokation
 	Geoadresse          *com.Geokoordinaten  `json:"geoadresse" validate:"required_without_all=Messadresse Katasterinformation"` // Geoadresse are gps coordinates of the Messlokation

--- a/bo/netznutzungsrechnung.go
+++ b/bo/netznutzungsrechnung.go
@@ -9,12 +9,12 @@ import (
 // Netznutzungsrechnung models grid usage invoices
 type Netznutzungsrechnung struct {
 	Rechnung
-	Sparte               sparte.Sparte                 `json:"sparte,omitempty" validate:"required"`                              // Sparte (STROM, GAS ...) für die die Rechnung ausgestellt ist
-	Absendercodenummer   string                        `json:"absendercodenummer" validate:"required,numeric,min=13,max=13"`      // Absendercodenummer ist die Rollencodenummer des Absenders (Rechnung.Rechnungsersteller). Über die Nummer können weitere Informationen zum Marktteilnehmer ermittelt werden.
-	Empfaengercodenummer string                        `json:"empfaengercodenummer" validate:"required,numeric,min=13,max=13"`    // Absendercodenummer ist die Rollencodenummer des Empfängers (Rechnung.Rechnungsempfaenger). Über die Nummer können weitere Informationen zum Marktteilnehmer ermittelt werden.
-	Nnrechnungsart       nnrechnungsart.NNRechnungsart `json:"nnrechnungsart,omitempty" validate:"required"`                      // Nnrechnungsart ist aus der INVOIC entnommen
-	Nnrechnungstyp       nnrechnungstyp.NNRechnungstyp `json:"nnrechnungstyp,omitempty" validate:"required"`                      // Nnrechnungstyp ist aus der INVOIC entnommen
-	Original             bool                          `json:"original"`                                                          // Original ist ein Kennzeichen, ob es sich um ein Original (true) oder eine Kopie handelt (false).
-	Simuliert            bool                          `json:"simuliert"`                                                         // Simuliert ist ein Kennzeichen, ob es sich um eine simulierte Rechnung, z.B. zur Rechnungsprüfung handelt.
-	LokationsId          string                        `json:"lokationsId,omitempty" validate:"omitempty,alphanum,max=33,min=11"` // LokationsId ist die Markt- oder Messlokations-Identifikation (als Malo/Melo-Id) der Lokation, auf die sich die Rechnung bezieht.
+	Sparte               sparte.Sparte                 `json:"sparte,omitempty" validate:"required"`                                     // Sparte (STROM, GAS ...) für die die Rechnung ausgestellt ist
+	Absendercodenummer   string                        `json:"absendercodenummer,omitempty" validate:"required,numeric,min=13,max=13"`   // Absendercodenummer ist die Rollencodenummer des Absenders (Rechnung.Rechnungsersteller). Über die Nummer können weitere Informationen zum Marktteilnehmer ermittelt werden.
+	Empfaengercodenummer string                        `json:"empfaengercodenummer,omitempty" validate:"required,numeric,min=13,max=13"` // Absendercodenummer ist die Rollencodenummer des Empfängers (Rechnung.Rechnungsempfaenger). Über die Nummer können weitere Informationen zum Marktteilnehmer ermittelt werden.
+	Nnrechnungsart       nnrechnungsart.NNRechnungsart `json:"nnrechnungsart,omitempty" validate:"required"`                             // Nnrechnungsart ist aus der INVOIC entnommen
+	Nnrechnungstyp       nnrechnungstyp.NNRechnungstyp `json:"nnrechnungstyp,omitempty" validate:"required"`                             // Nnrechnungstyp ist aus der INVOIC entnommen
+	Original             bool                          `json:"original"`                                                                 // Original ist ein Kennzeichen, ob es sich um ein Original (true) oder eine Kopie handelt (false).
+	Simuliert            bool                          `json:"simuliert"`                                                                // Simuliert ist ein Kennzeichen, ob es sich um eine simulierte Rechnung, z.B. zur Rechnungsprüfung handelt.
+	LokationsId          string                        `json:"lokationsId,omitempty" validate:"omitempty,alphanum,max=33,min=11"`        // LokationsId ist die Markt- oder Messlokations-Identifikation (als Malo/Melo-Id) der Lokation, auf die sich die Rechnung bezieht.
 }

--- a/bo/rechnung.go
+++ b/bo/rechnung.go
@@ -12,25 +12,25 @@ import (
 // Rechnung ist ein Modell für die Abbildung von Rechnungen im Kontext der Energiewirtschaft. Ausgehend von diesem Basismodell werden weitere spezifische Formen abgeleitet.
 type Rechnung struct {
 	Geschaeftsobjekt
-	Rechnungstitel          string                          `json:"rechnungstitel"`                                             // Rechnungstitel ist die Bezeichnung für die vorliegende Rechnung.
-	Rechnungsstatus         rechnungsstatus.Rechnungsstatus `json:"rechnungsstatus,omitempty"`                                  // Rechnungsstatus ist der Status der Rechnung zur Kennzeichnung des Bearbeitungsstandes
-	Storno                  bool                            `json:"storno" validate:"required"`                                 // Storno ist eine Kennzeichnung, ob es sich um eine Stornorechnung handelt. Im Falle "true" findet sich im Attribut "originalrechnungsnummer" die Nummer der Originalrechnung
-	Rechnungsnummer         string                          `json:"rechnungsnummer" validate:"required"`                        // Rechnungsnummer ist eine im Verwendungskontext eindeutige Nummer für die Rechnung
-	Rechnungsdatum          time.Time                       `json:"rechnungsdatum" validate:"required"`                         // Rechnungsdatum ist das Ausstellungsdatum der Rechnung
-	Faelligkeitsdatum       time.Time                       `json:"faelligkeitsdatum" validate:"required"`                      // Faelligkeitsdatum ist das Datum, zu dem die Zahlung fällig ist
-	Rechnungstyp            rechnungstyp.Rechnungstyp       `json:"rechnungstyp,omitempty" validate:"required"`                 // Rechnungstyp ist ein kontextbezogener Rechnungstyp
-	OriginalRechnungsnummer string                          `json:"originalRechnungsnummer" validate:"required_if=Storno true"` // OriginalRechnungsnummer: Im Falle einer Stornorechnung (Storno = true) steht hier die Rechnungsnummer der stornierten Rechnung
-	Rechnungsperiode        com.Zeitraum                    `json:"rechnungsperiode" validate:"required"`                       // Rechnungsperiode ist der Zeitraum der zugrunde liegenden Lieferung zur Rechnung
-	Rechnungsersteller      Geschaeftspartner               `json:"rechnungsersteller" validate:"required"`                     // Rechnungsersteller ist der Aussteller der Rechnung
-	Rechnungsempfaenger     Geschaeftspartner               `json:"rechnungsempfaenger" validate:"required"`                    // Rechnungsempfaenger ist der Empfänger der Rechnung
-	GesamtNetto             com.Betrag                      `json:"gesamtnetto" validate:"required"`                            // GesamtNetto ist die Summe der Nettobeträge der Rechnungsteile
-	GesamtSteuer            com.Betrag                      `json:"gesamtsteuer" validate:"required"`                           // GesamtSteuer ist die Summe der Steuerbeträge der Rechnungsteile
-	GesamtBrutto            com.Betrag                      `json:"gesamtbrutto" validate:"required"`                           // GesamtBrutto ist die Summe aus Netto- und Steuerbeträge
-	Vorausgezahlt           *com.Betrag                     `json:"vorausgezahlt"`                                              // Vorausgezahlt ist die Summe eventuell vorausbezahlter Beträge, z.B. Abschläge. Angabe als Bruttowert.
-	RabattBrutto            *com.Betrag                     `json:"rabattBrutto"`                                               // RabattBrutto ist der Gesamtrabatt auf den Bruttobetrag
-	Zuzahlen                com.Betrag                      `json:"zuzahlen" validate:"required"`                               // Zuzahlen ist der zu zahlende Betrag, der sich aus (gesamtbrutto - vorausbezahlt - rabattBrutto) ergibt
-	Steuerbetraege          []com.Steuerbetrag              `json:"steuerbetraege"`                                             // Steuerbetraege ist eine Liste mit Steuerbeträgen pro Steuerkennzeichen/Steuersatz. Die Summe dieser Beträge ergibt den Wert für GesamtSteuer
-	Rechnungspositionen     []com.Rechnungsposition         `json:"rechnungspositionen" validate:"required,min=1"`              // Rechnungspositionen sind die einzelnen Rechnungsposition en.
+	Rechnungstitel          string                          `json:"rechnungstitel,omitempty"`                                             // Rechnungstitel ist die Bezeichnung für die vorliegende Rechnung.
+	Rechnungsstatus         rechnungsstatus.Rechnungsstatus `json:"rechnungsstatus,omitempty"`                                            // Rechnungsstatus ist der Status der Rechnung zur Kennzeichnung des Bearbeitungsstandes
+	Storno                  bool                            `json:"storno" validate:"required"`                                           // Storno ist eine Kennzeichnung, ob es sich um eine Stornorechnung handelt. Im Falle "true" findet sich im Attribut "originalrechnungsnummer" die Nummer der Originalrechnung
+	Rechnungsnummer         string                          `json:"rechnungsnummer,omitempty" validate:"required"`                        // Rechnungsnummer ist eine im Verwendungskontext eindeutige Nummer für die Rechnung
+	Rechnungsdatum          time.Time                       `json:"rechnungsdatum,omitempty" validate:"required"`                         // Rechnungsdatum ist das Ausstellungsdatum der Rechnung
+	Faelligkeitsdatum       time.Time                       `json:"faelligkeitsdatum,omitempty" validate:"required"`                      // Faelligkeitsdatum ist das Datum, zu dem die Zahlung fällig ist
+	Rechnungstyp            rechnungstyp.Rechnungstyp       `json:"rechnungstyp,omitempty" validate:"required"`                           // Rechnungstyp ist ein kontextbezogener Rechnungstyp
+	OriginalRechnungsnummer string                          `json:"originalRechnungsnummer,omitempty" validate:"required_if=Storno true"` // OriginalRechnungsnummer: Im Falle einer Stornorechnung (Storno = true) steht hier die Rechnungsnummer der stornierten Rechnung
+	Rechnungsperiode        com.Zeitraum                    `json:"rechnungsperiode,omitempty" validate:"required"`                       // Rechnungsperiode ist der Zeitraum der zugrunde liegenden Lieferung zur Rechnung
+	Rechnungsersteller      Geschaeftspartner               `json:"rechnungsersteller,omitempty" validate:"required"`                     // Rechnungsersteller ist der Aussteller der Rechnung
+	Rechnungsempfaenger     Geschaeftspartner               `json:"rechnungsempfaenger,omitempty" validate:"required"`                    // Rechnungsempfaenger ist der Empfänger der Rechnung
+	GesamtNetto             com.Betrag                      `json:"gesamtnetto,omitempty" validate:"required"`                            // GesamtNetto ist die Summe der Nettobeträge der Rechnungsteile
+	GesamtSteuer            com.Betrag                      `json:"gesamtsteuer,omitempty" validate:"required"`                           // GesamtSteuer ist die Summe der Steuerbeträge der Rechnungsteile
+	GesamtBrutto            com.Betrag                      `json:"gesamtbrutto,omitempty" validate:"required"`                           // GesamtBrutto ist die Summe aus Netto- und Steuerbeträge
+	Vorausgezahlt           *com.Betrag                     `json:"vorausgezahlt,omitempty"`                                              // Vorausgezahlt ist die Summe eventuell vorausbezahlter Beträge, z.B. Abschläge. Angabe als Bruttowert.
+	RabattBrutto            *com.Betrag                     `json:"rabattBrutto,omitempty"`                                               // RabattBrutto ist der Gesamtrabatt auf den Bruttobetrag
+	Zuzahlen                com.Betrag                      `json:"zuzahlen,omitempty" validate:"required"`                               // Zuzahlen ist der zu zahlende Betrag, der sich aus (gesamtbrutto - vorausbezahlt - rabattBrutto) ergibt
+	Steuerbetraege          []com.Steuerbetrag              `json:"steuerbetraege,omitempty"`                                             // Steuerbetraege ist eine Liste mit Steuerbeträgen pro Steuerkennzeichen/Steuersatz. Die Summe dieser Beträge ergibt den Wert für GesamtSteuer
+	Rechnungspositionen     []com.Rechnungsposition         `json:"rechnungspositionen,omitempty" validate:"required,min=1"`              // Rechnungspositionen sind die einzelnen Rechnungsposition en.
 }
 
 // RechnungStructLevelValidation combines all the single validators

--- a/bo/vertrag.go
+++ b/bo/vertrag.go
@@ -11,17 +11,17 @@ import (
 // Vertrag ist ein Modell für die Abbildung von Vertragsbeziehungen. Das Objekt dient dazu, alle Arten von Verträgen, die in der Energiewirtschaft Verwendung finden, abzubilden.
 type Vertrag struct {
 	Geschaeftsobjekt
-	Vertragsnummer      string                        `json:"vertragsnummer" validate:"alphanum,required"`         // Vertragsnummer ist eine im Verwendungskontext eindeutige Nummer für den Vertrag
-	Beschreibung        string                        `json:"beschreibung,omitempty"`                              // Beschreibung zum Vertrag
-	Vertragsstatus      vertragsstatus.Vertragsstatus `json:"vertragsstatus,omitempty" validate:"required"`        // Vertragsstatus ist der Status des Vertrags
-	Vertragsart         vertragsart.Vertragsart       `json:"vertragsart,omitempty" validate:"required"`           // Vertragsart legt fest, um welche Art von Vertrag es sich handelt. Z.B. Netznutzungvertrag.
-	Sparte              sparte.Sparte                 `json:"sparte,omitempty" validate:"required"`                // Sparte sind Unterscheidungsmöglichkeiten für die Sparte
-	Vertragsbeginn      time.Time                     `json:"startdatum" validate:"required"`                      // Vertragsbeginn is the inclusive start
-	Vertragsende        time.Time                     `json:"enddatum" validate:"required,gtfield=Vertragsbeginn"` // Vertragsende is the exclusive end
-	Vertragspartner1    Geschaeftspartner             `json:"vertragspartner1" validate:"required"`                // Vertragspartner1 ist der "erstgenannte" Vertragspartner. In der Regel der Aussteller des Vertrags. Beispiel: "Vertrag zwischen Vertragspartner 1 ..."
-	Vertragspartner2    Geschaeftspartner             `json:"vertragspartner2" validate:"required"`                // Vertragspartner2 ist der "zweitgenannte" Vertragspartner. In der Regel der Empfänger des Vertrags. Beispiel "Vertrag zwischen Vertragspartner 1 und Vertragspartner 2"
-	UnterzeichnerVp1    []com.Unterschrift            `json:"unterzeichnervp1,omitempty"`                          // UnterzeichnerVp1 ist der Unterzeichner des Vertragspartner1
-	UnterzeichnerVp2    []com.Unterschrift            `json:"unterzeichnervp2,omitempty"`                          // UnterzeichnerVp2 ist der Unterzeichner des Vertragspartner2
-	Vertragskonditionen *com.Vertragskonditionen      `json:"vertragskonditionen,omitempty"`                       // Vertragskonditionen ist eine Festlegungen zu Laufzeiten und Kündigungsfristen
-	Vertragsteile       []com.Vertragsteil            `json:"vertragsteile" validate:"required,min=1"`             // Vertragsteile sind die Vertragsteile, die dazu verwendet werden, eine vertragliche Leistung in Bezug zu einer Lokation (Markt- oder Messlokation) festzulegen.
+	Vertragsnummer      string                        `json:"vertragsnummer,omitempty" validate:"alphanum,required"`         // Vertragsnummer ist eine im Verwendungskontext eindeutige Nummer für den Vertrag
+	Beschreibung        string                        `json:"beschreibung,omitempty"`                                        // Beschreibung zum Vertrag
+	Vertragsstatus      vertragsstatus.Vertragsstatus `json:"vertragsstatus,omitempty" validate:"required"`                  // Vertragsstatus ist der Status des Vertrags
+	Vertragsart         vertragsart.Vertragsart       `json:"vertragsart,omitempty" validate:"required"`                     // Vertragsart legt fest, um welche Art von Vertrag es sich handelt. Z.B. Netznutzungvertrag.
+	Sparte              sparte.Sparte                 `json:"sparte,omitempty" validate:"required"`                          // Sparte sind Unterscheidungsmöglichkeiten für die Sparte
+	Vertragsbeginn      time.Time                     `json:"startdatum,omitempty" validate:"required"`                      // Vertragsbeginn is the inclusive start
+	Vertragsende        time.Time                     `json:"enddatum,omitempty" validate:"required,gtfield=Vertragsbeginn"` // Vertragsende is the exclusive end
+	Vertragspartner1    Geschaeftspartner             `json:"vertragspartner1,omitempty" validate:"required"`                // Vertragspartner1 ist der "erstgenannte" Vertragspartner. In der Regel der Aussteller des Vertrags. Beispiel: "Vertrag zwischen Vertragspartner 1 ..."
+	Vertragspartner2    Geschaeftspartner             `json:"vertragspartner2,omitempty" validate:"required"`                // Vertragspartner2 ist der "zweitgenannte" Vertragspartner. In der Regel der Empfänger des Vertrags. Beispiel "Vertrag zwischen Vertragspartner 1 und Vertragspartner 2"
+	UnterzeichnerVp1    []com.Unterschrift            `json:"unterzeichnervp1,omitempty"`                                    // UnterzeichnerVp1 ist der Unterzeichner des Vertragspartner1
+	UnterzeichnerVp2    []com.Unterschrift            `json:"unterzeichnervp2,omitempty"`                                    // UnterzeichnerVp2 ist der Unterzeichner des Vertragspartner2
+	Vertragskonditionen *com.Vertragskonditionen      `json:"vertragskonditionen,omitempty"`                                 // Vertragskonditionen ist eine Festlegungen zu Laufzeiten und Kündigungsfristen
+	Vertragsteile       []com.Vertragsteil            `json:"vertragsteile,omitempty" validate:"required,min=1"`             // Vertragsteile sind die Vertragsteile, die dazu verwendet werden, eine vertragliche Leistung in Bezug zu einer Lokation (Markt- oder Messlokation) festzulegen.
 }

--- a/bo/zaehler.go
+++ b/bo/zaehler.go
@@ -13,14 +13,14 @@ import (
 // Zaehler ist ein Modell für die Abbildung der Informationen zu einem Zähler
 type Zaehler struct {
 	Geschaeftsobjekt
-	Zaehlernummer      string                                `json:"zaehlernummer" validate:"required,alphanum"`       // Zaehlernummer ist eine Nummerierung des Zaehlers, vergeben durch den Messstellenbetreiber
-	Sparte             sparte.Sparte                         `json:"sparte,omitempty" validate:"required"`             // Sparte ist eine Unterscheidungsmöglichkeit für die Sparte
-	Zaehlerauspraegung zaehlerauspraegung.Zaehlerauspraegung `json:"zaehlerauspraegung,omitempty" validate:"required"` // Zaehlerauspraegung ist eine Spezifikation die Richtung des Zählers betreffend
-	Zaehlertyp         zaehlertyp.Zaehlertyp                 `json:"zaehlertyp,omitempty" validate:"required"`         // Zaehlertyp erlaubt eine Typisierung des Zählers
-	Tarifart           tarifart.Tarifart                     `json:"tarifart,omitempty" validate:"required"`           // Tarifart erlaubt eine Spezifikation bezüglich unterstützter Tarifarten
-	Zaehlerkonstante   decimal.NullDecimal                   `json:"zaehlerkonstante,omitempty"`                       // Zaehlerkonstante ist die Zählerkonstante auf dem Zähler
-	EichungBis         time.Time                             `json:"eichungBis,omitempty"`                             // EichungBis ist das exklusive Enddatum bis zu dem der Zähler geeicht ist
-	LetzteEichung      time.Time                             `json:"letzteEichung,omitempty"`                          // LetzteEichung ist das Datum, an dem die letzte Eichprüfung des Zählers stattfand
-	Zaehlwerke         []com.Zaehlwerk                       `json:"zaehlwerke" validate:"required,min=1"`             // Zaehlwerke sind die Zählwerke des Zählers
-	Zaehlerhersteller  *Geschaeftspartner                    `json:"zaehlerhersteller,omitempty"`                      // Zaehlerhersteller ist der Hersteller des Zählers
+	Zaehlernummer      string                                `json:"zaehlernummer,omitempty" validate:"required,alphanum"` // Zaehlernummer ist eine Nummerierung des Zaehlers, vergeben durch den Messstellenbetreiber
+	Sparte             sparte.Sparte                         `json:"sparte,omitempty" validate:"required"`                 // Sparte ist eine Unterscheidungsmöglichkeit für die Sparte
+	Zaehlerauspraegung zaehlerauspraegung.Zaehlerauspraegung `json:"zaehlerauspraegung,omitempty" validate:"required"`     // Zaehlerauspraegung ist eine Spezifikation die Richtung des Zählers betreffend
+	Zaehlertyp         zaehlertyp.Zaehlertyp                 `json:"zaehlertyp,omitempty" validate:"required"`             // Zaehlertyp erlaubt eine Typisierung des Zählers
+	Tarifart           tarifart.Tarifart                     `json:"tarifart,omitempty" validate:"required"`               // Tarifart erlaubt eine Spezifikation bezüglich unterstützter Tarifarten
+	Zaehlerkonstante   decimal.NullDecimal                   `json:"zaehlerkonstante,omitempty"`                           // Zaehlerkonstante ist die Zählerkonstante auf dem Zähler
+	EichungBis         time.Time                             `json:"eichungBis,omitempty"`                                 // EichungBis ist das exklusive Enddatum bis zu dem der Zähler geeicht ist
+	LetzteEichung      time.Time                             `json:"letzteEichung,omitempty"`                              // LetzteEichung ist das Datum, an dem die letzte Eichprüfung des Zählers stattfand
+	Zaehlwerke         []com.Zaehlwerk                       `json:"zaehlwerke,omitempty" validate:"required,min=1"`       // Zaehlwerke sind die Zählwerke des Zählers
+	Zaehlerhersteller  *Geschaeftspartner                    `json:"zaehlerhersteller,omitempty"`                          // Zaehlerhersteller ist der Hersteller des Zählers
 }

--- a/com/Zeitreihenwert.go
+++ b/com/Zeitreihenwert.go
@@ -7,6 +7,6 @@ import (
 // Zeitreihenwert ist eine Abbildung eines Zeitreihenwertes bestehend aus Zeitraum, Wert und Statusinformationen.
 type Zeitreihenwert struct {
 	Zeitreihenwertkompakt
-	DatumUhrzeitVon time.Time `json:"datumUhrzeitVon" validate:"required" example:"2018-01-28T10:15:00+01"` // DatumUhrzeitVon is the inclusive begin
-	DatumUhrzeitBis time.Time `json:"datumUhrzeitBis" validate:"required" example:"2018-01-28T10:30:00+01"` // DatumUhrzeitBis is the exclusive end
+	DatumUhrzeitVon time.Time `json:"datumUhrzeitVon,omitempty" validate:"required" example:"2018-01-28T10:15:00+01"` // DatumUhrzeitVon is the inclusive begin
+	DatumUhrzeitBis time.Time `json:"datumUhrzeitBis,omitempty" validate:"required" example:"2018-01-28T10:30:00+01"` // DatumUhrzeitBis is the exclusive end
 }

--- a/com/dienstleistung.go
+++ b/com/dienstleistung.go
@@ -6,6 +6,6 @@ import (
 
 // A Dienstleistung is a billable Service
 type Dienstleistung struct {
-	DienstleistungsTyp dienstleistung.Dienstleistungstyp `json:"dienstleistungstyp,omitempty" validate:"required"` // DienstleistungsTyp describes the type of the service
-	Bezeichnung        string                            `json:"bezeichnung" validate:"alphaunicode,required"`     // Bezeichnung is a description
+	DienstleistungsTyp dienstleistung.Dienstleistungstyp `json:"dienstleistungstyp,omitempty" validate:"required"`       // DienstleistungsTyp describes the type of the service
+	Bezeichnung        string                            `json:"bezeichnung,omitempty" validate:"alphaunicode,required"` // Bezeichnung is a description
 }

--- a/com/hardware.go
+++ b/com/hardware.go
@@ -4,6 +4,6 @@ import "github.com/hochfrequenz/go-bo4e/enum/geraetetyp"
 
 // A Hardware is a billable device
 type Hardware struct {
-	GeraeteTyp  geraetetyp.Geraetetyp `json:"geraeteTyp,omitempty" validate:"required"`     // GeraeteTyp type of the hardware
-	Bezeichnung string                `json:"bezeichnung" validate:"alphaunicode,required"` // Bezeichnung is a description
+	GeraeteTyp  geraetetyp.Geraetetyp `json:"geraeteTyp,omitempty" validate:"required"`               // GeraeteTyp type of the hardware
+	Bezeichnung string                `json:"bezeichnung,omitempty" validate:"alphaunicode,required"` // Bezeichnung is a description
 }

--- a/com/katasteradresse.go
+++ b/com/katasteradresse.go
@@ -3,6 +3,6 @@ package com
 // Katasteradresse is a cadastre location
 type Katasteradresse struct {
 	// ToDo: why is this `gemarkung_flur` and not `gemarkungFlur`
-	GemarkungFlur string `json:"gemarkung_flur" validate:"required"` // GemarkungFlur is the district in which something is located
-	Flurstueck    string `json:"flurstueck" validate:"required"`     // Flurstueck describes the parcel
+	GemarkungFlur string `json:"gemarkung_flur,omitempty" validate:"required"` // GemarkungFlur is the district in which something is located
+	Flurstueck    string `json:"flurstueck,omitempty" validate:"required"`     // Flurstueck describes the parcel
 }

--- a/com/lastprofil.go
+++ b/com/lastprofil.go
@@ -5,8 +5,8 @@ import "github.com/hochfrequenz/go-bo4e/enum/profilverfahren"
 // Lastprofil defines a Lastprofil (no shit, sherlock)
 // Note that this component is not official BO4E standard (yet)!
 type Lastprofil struct {
-	Bezeichnung    string                          `json:"bezeichnung" validate:"omitempty,alphanum" example:"H0"` // Bezeichnung des Profils, durch DVGW bzw. den Netzbetreiber vergeben
-	Verfahren      profilverfahren.Profilverfahren `json:"verfahren,omitempty"`                                    // Verfahren des Profils (analytisch oder synthetisch)
-	Einspeisung    *bool                           `json:"einspeisung,omitempty"`                                  // Einspeisung ist true, falls es sich um Einspeisung handelt
-	Tagesparameter *Tagesparameter                 `json:"tagesparameter,omitempty"`                               // Tagesparameter contains the Klimazone or Temperaturmessstelle
+	Bezeichnung    string                          `json:"bezeichnung,omitempty" validate:"omitempty,alphanum" example:"H0"` // Bezeichnung des Profils, durch DVGW bzw. den Netzbetreiber vergeben
+	Verfahren      profilverfahren.Profilverfahren `json:"verfahren,omitempty"`                                              // Verfahren des Profils (analytisch oder synthetisch)
+	Einspeisung    *bool                           `json:"einspeisung,omitempty"`                                            // Einspeisung ist true, falls es sich um Einspeisung handelt
+	Tagesparameter *Tagesparameter                 `json:"tagesparameter,omitempty"`                                         // Tagesparameter contains the Klimazone or Temperaturmessstelle
 }

--- a/com/messlokationszuordnung.go
+++ b/com/messlokationszuordnung.go
@@ -9,6 +9,6 @@ import (
 type Messlokationszuordnung struct {
 	MesslokationsId string                                        `json:"messlokationsId,omitempty" validate:"required,alphanum,len=33"` // MesslokationsId, früher die Zählpunktbezeichnung.
 	Arithmetik      arithmetischeoperation.ArithmetischeOperation `json:"arithmetik,omitempty" validate:"required"`                      // Arithmetik ist die Operation, mit der eine Messung an dieser Lokation für den Gesamtverbrauch der Marktlokation verrechnet wird. Beispielsweise bei einer Untermessung, wird der Verbauch der Untermessung subtrahiert.
-	GueltigSeit     time.Time                                     `json:"gueltigSeit" validate:"ltefield=GueltigBis"`                    // GueltigSeit ist der inklusive Zeitpunkt, ab dem die Messlokation zur Marktlokation gehört
-	GueltigBis      time.Time                                     `json:"gueltigbis" validate:"gtefield=GueltigSeit"`                    // GueltigBis ist der exklusive Zeitpunkt, bis zu dem die Messlokation zur Marktlokation gehört
+	GueltigSeit     time.Time                                     `json:"gueltigSeit,omitempty" validate:"ltefield=GueltigBis"`          // GueltigSeit ist der inklusive Zeitpunkt, ab dem die Messlokation zur Marktlokation gehört
+	GueltigBis      time.Time                                     `json:"gueltigBis,omitempty" validate:"gtefield=GueltigSeit"`          // GueltigBis ist der exklusive Zeitpunkt, bis zu dem die Messlokation zur Marktlokation gehört
 }

--- a/com/rechnungsposition.go
+++ b/com/rechnungsposition.go
@@ -11,19 +11,19 @@ import (
 
 // Rechnungsposition en sind Teil von Rechnung en. In einem Rechnungsteil wird jeweils eine in sich geschlossene LEISTUNG abgerechnet.
 type Rechnungsposition struct {
-	Positionsnummer   int                                 `json:"positionsnummer" validate:"required"`                              // Positionsnummer ist eine fortlaufende Nummer für die Rechnungsposition
-	LieferungVon      time.Time                           `json:"lieferungVon" validate:"required"`                                 // LieferungVon ist ein _inklusiver_ Start der Lieferung für die abgerechnete LEISTUNG
-	LieferungBis      time.Time                           `json:"lieferungBis" validate:"required,gtfield=LieferungVon"`            // LieferungBis ist ein _exklusives_ Ende der Lieferung für die abgerechnete LEISTUNG
-	Positionstext     string                              `json:"positionstext" validate:"required"`                                // Positionstext ist eine Bezeichung für die abgerechnete Position.
+	Positionsnummer   int                                 `json:"positionsnummer,omitempty" validate:"required"`                    // Positionsnummer ist eine fortlaufende Nummer für die Rechnungsposition
+	LieferungVon      time.Time                           `json:"lieferungVon,omitempty" validate:"required"`                       // LieferungVon ist ein _inklusiver_ Start der Lieferung für die abgerechnete LEISTUNG
+	LieferungBis      time.Time                           `json:"lieferungBis,omitempty" validate:"required,gtfield=LieferungVon"`  // LieferungBis ist ein _exklusives_ Ende der Lieferung für die abgerechnete LEISTUNG
+	Positionstext     string                              `json:"positionstext,omitempty" validate:"required"`                      // Positionstext ist eine Bezeichung für die abgerechnete Position.
 	Zeiteinheit       zeiteinheit.Zeiteinheit             `json:"zeiteinheit,omitempty"`                                            // Zeiteinheit wird angegeben, falls sich der Preis auf eine Zeit bezieht, steht hier die Einheit, z.B. JAHR
 	Artikelnummer     bdewartikelnummer.BDEWArtikelnummer `json:"bdewartikelnummer,omitempty"`                                      // Artikelnummer ist eine Kennzeichnung der Rechnungsposition mit der Standard-Artikelnummer des BDEW
 	LokationsId       string                              `json:"lokationsId,omitempty" validate:"omitempty,min=11,max=11,numeric"` // LokationsId ist die MarktlokationsId zu der diese Position gehört
-	PositionsMenge    Menge                               `json:"positionsMenge" validate:"required"`                               // PositionsMenge ist die abgerechnete Menge mit Einheit. Z.B. 4372 kWh
-	ZeitbezogeneMenge *Menge                              `json:"zeitbezogeneMenge"`                                                // ZeitbezogeneMenge ist eine optionale, auf die Zeiteinheit bezogene Untermenge. Z.B. bei einem Jahrespreis, 3 Monate oder 146 Tage. Basierend darauf wird der Preis aufgeteilt
-	Einzelpreis       Preis                               `json:"einzelpreis" validate:"required"`                                  // Einzelpreis ist der Preis für eine Einheit der energetischen Menge
-	TeilsummeNetto    Betrag                              `json:"teilsummeNetto" validate:"required"`                               // TeilsummeNetto ist das Ergebnis der Multiplikation aus einzelpreis * positionsMenge * (Faktor aus zeitbezogeneMenge). Z.B. 12,60€ * 120 kW * 3/12 (für 3 Monate).
-	TeilsummeSteuer   Steuerbetrag                        `json:"teilsummeSteuer" validate:"required"`                              // TeilsummeSteuer ist der auf die Position entfallende Steuer, bestehend aus Steuersatz und Betrag
-	TeilrabattNetto   *Betrag                             `json:"teilrabattNetto"`                                                  // TeilrabattNetto ist der Rabatt für diese Position
+	PositionsMenge    Menge                               `json:"positionsMenge,omitempty" validate:"required"`                     // PositionsMenge ist die abgerechnete Menge mit Einheit. Z.B. 4372 kWh
+	ZeitbezogeneMenge *Menge                              `json:"zeitbezogeneMenge,omitempty"`                                      // ZeitbezogeneMenge ist eine optionale, auf die Zeiteinheit bezogene Untermenge. Z.B. bei einem Jahrespreis, 3 Monate oder 146 Tage. Basierend darauf wird der Preis aufgeteilt
+	Einzelpreis       Preis                               `json:"einzelpreis,omitempty" validate:"required"`                        // Einzelpreis ist der Preis für eine Einheit der energetischen Menge
+	TeilsummeNetto    Betrag                              `json:"teilsummeNetto,omitempty" validate:"required"`                     // TeilsummeNetto ist das Ergebnis der Multiplikation aus einzelpreis * positionsMenge * (Faktor aus zeitbezogeneMenge). Z.B. 12,60€ * 120 kW * 3/12 (für 3 Monate).
+	TeilsummeSteuer   Steuerbetrag                        `json:"teilsummeSteuer,omitempty" validate:"required"`                    // TeilsummeSteuer ist der auf die Position entfallende Steuer, bestehend aus Steuersatz und Betrag
+	TeilrabattNetto   *Betrag                             `json:"teilrabattNetto,omitempty"`                                        // TeilrabattNetto ist der Rabatt für diese Position
 }
 
 // RechnungspositionStructLevelValidation does a cross check on a Rechnungsposition object

--- a/com/rufnummer.go
+++ b/com/rufnummer.go
@@ -4,6 +4,6 @@ import "github.com/hochfrequenz/go-bo4e/enum/rufnummernart"
 
 // Rufnummer bildet eine Telefonnummer ab
 type Rufnummer struct {
-	Nummerntyp rufnummernart.Rufnummernart `json:"nummerntyp" validate:"required"`                           // Nummerntyp ist die Ausprägung der Nummer
-	Rufnummer  string                      `json:"rufnummer" validate:"required" example:"4989209090153910"` // Rufnummer ist die konkrete Rufnummer
+	Nummerntyp rufnummernart.Rufnummernart `json:"nummerntyp,omitempty" validate:"required"`                           // Nummerntyp ist die Ausprägung der Nummer
+	Rufnummer  string                      `json:"rufnummer,omitempty" validate:"required" example:"4989209090153910"` // Rufnummer ist die konkrete Rufnummer
 }

--- a/com/tagesparameter.go
+++ b/com/tagesparameter.go
@@ -2,7 +2,7 @@ package com
 
 // Tagesparameter speichert Informationen zu einer tagesparameter-abhängigen Messstelle. z.B. den Namen einer Klimazone oder die ID der Wetterstation für die Temperaturmessstelle
 type Tagesparameter struct {
-	Klimazone            string `json:"klimazone" validate:"required,alphanum" example:"7624q"`            // Klimazone is the qualifier of the climate zone
-	Temperaturmessstelle string `json:"temperaturmessstelle" validate:"required,alphanum" example:"1234x"` // Klimazone is the qualifier of the temperature measurement station
-	Dienstanbieter       string `json:"dienstanbieter" validate:"required_with=Temperaturmessstelle"`      // Dienstanbieter is the service provider for temperature measurements
+	Klimazone            string `json:"klimazone,omitempty" validate:"required,alphanum" example:"7624q"`            // Klimazone is the qualifier of the climate zone
+	Temperaturmessstelle string `json:"temperaturmessstelle,omitempty" validate:"required,alphanum" example:"1234x"` // Klimazone is the qualifier of the temperature measurement station
+	Dienstanbieter       string `json:"dienstanbieter,omitempty" validate:"required_with=Temperaturmessstelle"`      // Dienstanbieter is the service provider for temperature measurements
 }

--- a/com/unterschrift.go
+++ b/com/unterschrift.go
@@ -6,7 +6,7 @@ import (
 
 // Unterschrift ist die Modellierung einer Unterschrift, z.B. für Verträge, Angebote etc.
 type Unterschrift struct {
-	Name  string    `json:"name" validate:"required"`   // Name des Unterschreibers
-	Datum time.Time `json:"datum" validate:"omitempty"` // Datum der Unterschrift
-	Ort   string    `json:"ort" validate:"omitempty"`   // Ort, an dem die Unterschrift geleistet wird
+	Name  string    `json:"name,omitempty" validate:"required"`   // Name des Unterschreibers
+	Datum time.Time `json:"datum,omitempty" validate:"omitempty"` // Datum der Unterschrift
+	Ort   string    `json:"ort,omitempty" validate:"omitempty"`   // Ort, an dem die Unterschrift geleistet wird
 }

--- a/com/verbrauch.go
+++ b/com/verbrauch.go
@@ -9,10 +9,10 @@ import (
 
 // Verbrauch is a a consumption during a specific time frame
 type Verbrauch struct {
-	Startdatum               time.Time                                         `json:"startdatum" validate:"omitempty"`                        // Startdatum is an inclusive start
-	Enddatum                 time.Time                                         `json:"enddatum" validate:"omitempty,gtfield=Startdatum"`       // Enddatum is an exclusive end
-	Wertermittlungsverfahren wertermittlungsverfahren.Wertermittlungsverfahren `json:"wertermittlungsverfahren,omitempty" validate:"required"` // Wertermittlungsverfahren is the type of the consumption
-	Obiskennzahl             string                                            `json:"obiskennzahl" validate:"required" example:"1-0:1.8.1"`   // Obiskennzahl is the OBIS Kennzahl // (?<power>(1)-((?:[0-5]?[0-9])|(?:6[0-5])):((?:[1-8]|99))\.((?:6|8|9|29))\.([0-9]{1,2}))||(?<gas>)(7)-((?:[0-5]?[0-9])|(?:6[0-5])):(.{1,2})\.(.{1,2})\.([0-9]{1,2})
-	Wert                     decimal.Decimal                                   `json:"wert" validate:"required" example:"17"`                  // Wert is the value (of einheit)
-	Einheit                  mengeneinheit.Mengeneinheit                       `json:"einheit,omitempty" validate:"required" example:"KWH"`    // Einheit is the unit (associated to the wert)
+	Startdatum               time.Time                                         `json:"startdatum,omitempty" validate:"omitempty"`                      // Startdatum is an inclusive start
+	Enddatum                 time.Time                                         `json:"enddatum,omitempty" validate:"omitempty,gtfield=Startdatum"`     // Enddatum is an exclusive end
+	Wertermittlungsverfahren wertermittlungsverfahren.Wertermittlungsverfahren `json:"wertermittlungsverfahren,omitempty" validate:"required"`         // Wertermittlungsverfahren is the type of the consumption
+	Obiskennzahl             string                                            `json:"obiskennzahl,omitempty" validate:"required" example:"1-0:1.8.1"` // Obiskennzahl is the OBIS Kennzahl // (?<power>(1)-((?:[0-5]?[0-9])|(?:6[0-5])):((?:[1-8]|99))\.((?:6|8|9|29))\.([0-9]{1,2}))||(?<gas>)(7)-((?:[0-5]?[0-9])|(?:6[0-5])):(.{1,2})\.(.{1,2})\.([0-9]{1,2})
+	Wert                     decimal.Decimal                                   `json:"wert,omitempty" validate:"required" example:"17"`                // Wert is the value (of einheit)
+	Einheit                  mengeneinheit.Mengeneinheit                       `json:"einheit,omitempty" validate:"required" example:"KWH"`            // Einheit is the unit (associated to the wert)
 }

--- a/com/vertragsteil.go
+++ b/com/vertragsteil.go
@@ -4,10 +4,10 @@ import "time"
 
 // Vertragsteil wird dazu verwendet, eine vertragliche Leistung in Bezug zu einer Lokation (Markt- oder Messlokation) festzulegen.
 type Vertragsteil struct {
-	Vertragsteilbeginn       time.Time `json:"vertragsteilbeginn" validate:"required"`                          // Vertragsteilbeginn ist der inklusive Start der Gültigkeit des Vertragsteils
-	Vertragsteilende         time.Time `json:"Vertragsteilende" validate:"required,gtfield=Vertragsteilbeginn"` // Vertragsteilende ist das exklusive Ende der Gültigkeit des Vertragsteils
-	Lokation                 string    `json:"lokation" validate:"omitempty,alphanum,min=11,max=33"`            // Lokation ist der Identifier für diejenigen Markt- oder Messlokation, die zu diesem Vertragsteil gehören. Verträge für mehrere Lokationen werden mit mehreren Vertragsteilen abgebildet.
-	VertraglichFixierteMenge *Menge    `json:"vertraglichFixierteMenge"`                                        // VertraglichFixierteMenge ist die für die Lokation festgeschriebene Abnahmemenge
-	MinimaleAbnahmemenge     *Menge    `json:"minimaleAbnahmemenge"`                                            // MinimaleAbnahmemenge ist die, für die Lokation festgelegte Mindestabnahmemenge
-	MaximaleAbnahmemenge     *Menge    `json:"maximaleAbnahmemenge"`                                            // MaximaleAbnahmemenge ist die, für die Lokation festgelegte maximale Abnahmemenge
+	Vertragsteilbeginn       time.Time `json:"vertragsteilbeginn,omitempty" validate:"required"`                          // Vertragsteilbeginn ist der inklusive Start der Gültigkeit des Vertragsteils
+	Vertragsteilende         time.Time `json:"Vertragsteilende,omitempty" validate:"required,gtfield=Vertragsteilbeginn"` // Vertragsteilende ist das exklusive Ende der Gültigkeit des Vertragsteils
+	Lokation                 string    `json:"lokation,omitempty" validate:"omitempty,alphanum,min=11,max=33"`            // Lokation ist der Identifier für diejenigen Markt- oder Messlokation, die zu diesem Vertragsteil gehören. Verträge für mehrere Lokationen werden mit mehreren Vertragsteilen abgebildet.
+	VertraglichFixierteMenge *Menge    `json:"vertraglichFixierteMenge,omitempty"`                                        // VertraglichFixierteMenge ist die für die Lokation festgeschriebene Abnahmemenge
+	MinimaleAbnahmemenge     *Menge    `json:"minimaleAbnahmemenge,omitempty"`                                            // MinimaleAbnahmemenge ist die, für die Lokation festgelegte Mindestabnahmemenge
+	MaximaleAbnahmemenge     *Menge    `json:"maximaleAbnahmemenge,omitempty"`                                            // MaximaleAbnahmemenge ist die, für die Lokation festgelegte maximale Abnahmemenge
 }

--- a/com/zaehlerstand.go
+++ b/com/zaehlerstand.go
@@ -9,7 +9,7 @@ import (
 
 // Zaehlerstand is the value of a meter for a specific point in time (non-standard)
 type Zaehlerstand struct {
-	Ablesedatum              time.Time                                         `json:"ablesedatum" validate:"required"`                        // Ablesedatum is a point in time
+	Ablesedatum              time.Time                                         `json:"ablesedatum,omitempty" validate:"required"`              // Ablesedatum is a point in time
 	Wertermittlungsverfahren wertermittlungsverfahren.Wertermittlungsverfahren `json:"wertermittlungsverfahren,omitempty" validate:"required"` // Wertermittlungsverfahren is the type of the consumption
 	Wert                     decimal.Decimal                                   `json:"wert" validate:"required" example:"17086"`               // Wert is the value (of Einheit)
 	Einheit                  mengeneinheit.Mengeneinheit                       `json:"einheit,omitempty" validate:"required" example:"KWH"`    // Einheit ist the unit (associated to the wert)

--- a/com/zaehlwerk.go
+++ b/com/zaehlwerk.go
@@ -8,11 +8,11 @@ import (
 
 // A Zaehlwerk is the counting part of a meter. A meter consists of one or more Zaehlwerke
 type Zaehlwerk struct {
-	ZaehlwerkId    string                          `json:"zaehlwerkId" validate:"required" example:"47110815_1"`          // ZaehlwerkId ist die Identifikation des Zählwerks (Registers) innerhalb des Zählers. Oftmals eine laufende Nummer hinter der Zählernummer.
-	Bezeichnung    string                          `json:"bezeichnung" validate:"required" example:"Zählwerk_Wirkarbeit"` // Bezeichnung ist eine zusätzliche Bezeichnung
-	Richtung       energierichtung.Energierichtung `json:"richtung,omitempty" validate:"required"`                        // Richtung beschreibt die Energierichtung: Einspeisung oder Ausspeisung.
-	ObisKennzahl   string                          `json:"obisKennzahl" validate:"required" example:"1-0:1.8.1"`          // Die ObisKennzahl für das Zählwerk, die festlegt, welche auf die gemessene Größe mit dem Stand gemeldet wird. Nur Zählwerkstände mit dieser OBIS-Kennzahl werden an diesem Zählwerk registriert.
-	Wandlerfaktor  decimal.Decimal                 `json:"wandlerfaktor" validate:"required"`                             // Der Wandlerfaktor ist der Faktor, mit dem die Zählerstandsdifferenz multipliziert wird, um zum eigentlichen Verbrauch im Zeitraum zu kommen.
-	Einheit        mengeneinheit.Mengeneinheit     `json:"einheit,omitempty" validate:"required"`                         // Die Einheit der gemessenen Größe
-	Zaehlerstaende Zaehlerstaende                  `json:"zaehlerstaende,omitempty"`                                      // A list of Zaehlerstand (Non BO4E Standard)
+	ZaehlwerkId    string                          `json:"zaehlwerkId,omitempty" validate:"required" example:"47110815_1"`          // ZaehlwerkId ist die Identifikation des Zählwerks (Registers) innerhalb des Zählers. Oftmals eine laufende Nummer hinter der Zählernummer.
+	Bezeichnung    string                          `json:"bezeichnung,omitempty" validate:"required" example:"Zählwerk_Wirkarbeit"` // Bezeichnung ist eine zusätzliche Bezeichnung
+	Richtung       energierichtung.Energierichtung `json:"richtung,omitempty" validate:"required"`                                  // Richtung beschreibt die Energierichtung: Einspeisung oder Ausspeisung.
+	ObisKennzahl   string                          `json:"obisKennzahl,omitempty" validate:"required" example:"1-0:1.8.1"`          // Die ObisKennzahl für das Zählwerk, die festlegt, welche auf die gemessene Größe mit dem Stand gemeldet wird. Nur Zählwerkstände mit dieser OBIS-Kennzahl werden an diesem Zählwerk registriert.
+	Wandlerfaktor  decimal.Decimal                 `json:"wandlerfaktor" validate:"required"`                                       // Der Wandlerfaktor ist der Faktor, mit dem die Zählerstandsdifferenz multipliziert wird, um zum eigentlichen Verbrauch im Zeitraum zu kommen.
+	Einheit        mengeneinheit.Mengeneinheit     `json:"einheit,omitempty" validate:"required"`                                   // Die Einheit der gemessenen Größe
+	Zaehlerstaende Zaehlerstaende                  `json:"zaehlerstaende,omitempty"`                                                // A list of Zaehlerstand (Non BO4E Standard)
 }


### PR DESCRIPTION
So far values of fields that are required had been serialized/marshalled. Just default values of non-required fields had been ignored during serialization.

To further decouple serialization and validation this PR introduces a different default value behaviour: All fields except for booleans (default `false`) and integers and decimals (default `0`) will no longer serialize.