### PR TITLE
Extract JSON field names via reflection

### DIFF
--- a/bo/bilanzierung.go
+++ b/bo/bilanzierung.go
@@ -3,6 +3,9 @@ package bo
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"time"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	aggregationsverantwortung "github.com/hochfrequenz/go-bo4e/enum/aggregationsverwantwortung"
@@ -10,9 +13,8 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/profiltyp"
 	"github.com/hochfrequenz/go-bo4e/enum/prognosegrundlage"
 	"github.com/hochfrequenz/go-bo4e/enum/zeitreihentyp"
+	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 	"github.com/shopspring/decimal"
-	"regexp"
-	"time"
 )
 
 // Bilanzierung is a business object used for balancing.
@@ -40,32 +42,10 @@ type Bilanzierung struct {
 	MarktlokationsId           string                                              `json:"marktlokationsId,omitempty" validate:"omitempty,maloid"` // MarktlokationsId referenziert eine Marktlokation
 }
 
-// bilanzierungJsonKeys is a list of all keys in the standard bo4e json Bilanzierung.
-// It is used to distinguish fields that can be mapped to the Marktlokation struct and those that are moved to Geschaeftsobjekt.ExtensionData
-var bilanzierungJsonKeys = []string{
-	// https://c.tenor.com/71HGq_GX1pMAAAAC/kill-me-simpsons.gif
-	// there has to be a better way than this.
-	"boTyp",
-	"versionStruktur",
-	"lastprofile",
-	"bilanzierungsbeginn",
-	"bilanzierungsende",
-	"bilanzkreis",
-	"jahresverbrauchsprognose",
-	"kundenwert",
-	"verbrauchsaufteilung",
-	"zeitreihentyp",
-	"aggregationsverantwortung",
-	"prognosegrundlage",
-	"detailsPrognosegrundlage",
-	"wahlrechtPrognosegrundlage",
-	"fallgruppenzuordnung",
-	"prioritaet",
-	"marktlokationsId",
-}
-
-func (_ Bilanzierung) GetDefaultJsonTags() []string {
-	return bilanzierungJsonKeys
+func (bila Bilanzierung) GetDefaultJsonTags() []string {
+	// We know we pass a struct here so ignore the error.
+	fields, _ := jsonfieldnames.Extract(bila)
+	return fields
 }
 
 // the bilanzierungForMarshal type is derived from Bilanzierung but uses a different unmarshaler/deserializer so that we don't run into an endless recursion when overriding the UnmarshalJSON func to include our hacky workaround

--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -2,6 +2,8 @@ package bo
 
 import (
 	"encoding/json"
+	"regexp"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/bilanzierungsmethode"
@@ -11,7 +13,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/netzebene"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/verbrauchsart"
-	"regexp"
+	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 )
 
 // Marktlokation contains information about a market location aka "MaLo"
@@ -95,35 +97,10 @@ func (malo Marktlokation) MarshalJSON() ([]byte, error) {
 	return json.Marshal(result)
 }
 
-func (_ Marktlokation) GetDefaultJsonTags() []string {
-	// As soon as we try to generalize this to not only cover Marktlokation, we need a better solution like applying reflection and then looping over the fields and reading the json tags.
-	return marktlokationJsonKeys
-}
-
-// marktlokationJsonKeys is a list of all keys in the standard bo4e json Marklokation. It is used to distinguish fields that can be mapped to the Marktlokation struct and those that are moved to Geschaeftsobjekt.ExtensionData
-var marktlokationJsonKeys = []string{
-	// https://c.tenor.com/71HGq_GX1pMAAAAC/kill-me-simpsons.gif
-	// there has to be a better way than this.
-	"boTyp",
-	"versionStruktur",
-	"marktlokationsId",
-	"sparte",
-	"energierichtung",
-	"bilanzierungsmethode",
-	"verbrauchsart",
-	"unterbrechbar",
-	"netzebene",
-	"netzbetreibercodenr",
-	"gebiettyp",
-	"netzgebietnr",
-	"bilanzierungsgebiet",
-	"grundversorgercodenr",
-	"gasqualitaet",
-	"endkunde",
-	"lokationsadresse",
-	"geoadresse",
-	"katasterinformation",
-	"zugehoerigemesslokationen",
+func (malo Marktlokation) GetDefaultJsonTags() []string {
+	// We know we pass a struct here so ignore the error.
+	fields, _ := jsonfieldnames.Extract(malo)
+	return fields
 }
 
 var elevenDigitsRegex = regexp.MustCompile(`^[1-9]\d{10}$`)

--- a/bo/messlokation.go
+++ b/bo/messlokation.go
@@ -2,10 +2,12 @@ package bo
 
 import (
 	"encoding/json"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/netzebene"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
+	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 )
 
 // Messlokation contains information about a metering location aka "MeLo"
@@ -26,26 +28,6 @@ type Messlokation struct {
 	Katasterinformation *com.Katasteradresse `json:"katasterinformation,omitempty" validate:"required_without_all=Messadresse Geoadresse"` // Katasterinformation is a cadastre address of the Messlokation
 }
 
-// messlokationJsonKeys is a list of all keys in the standard bo4e json Messlokation. It is used to distinguish fields that can be mapped to the Messlokation struct and those that are moved to Geschaeftsobjekt.ExtensionData
-var messlokationJsonKeys = []string{
-	// https://c.tenor.com/71HGq_GX1pMAAAAC/kill-me-simpsons.gif
-	// there has to be a better way than this.
-	"boTyp",
-	"versionStruktur",
-	"messlokationsId",
-	"sparte",
-	"netzebeneMessung",
-	"messgebietNr",
-	"geraete",
-	"messdienstleistung",
-	"grundzustaendigerMSBCodeNr",
-	"GrundzustaendigerMsbImCodeNr",
-	"messlokationszaehler",
-	"messadresse",
-	"geoadresse",
-	"katasterinformation",
-}
-
 // XorStructLevelMesslokationValidation ensures that only one of the possible address types is given
 func XorStructLevelMesslokationValidation(sl validator.StructLevel) {
 	melo := sl.Current().Interface().(Messlokation)
@@ -62,7 +44,9 @@ func XorStructLevelMesslokationValidation(sl validator.StructLevel) {
 }
 
 func (melo Messlokation) GetDefaultJsonTags() []string {
-	return messlokationJsonKeys
+	// We know we pass a struct here so ignore the error.
+	fields, _ := jsonfieldnames.Extract(melo)
+	return fields
 }
 
 // the below code is just copy pasted from the malo

--- a/internal/jsonfieldnames/extract.go
+++ b/internal/jsonfieldnames/extract.go
@@ -83,7 +83,7 @@ func extractFromField(field reflect.StructField) []string {
 	}
 }
 
-// jsonFieldNameFromTag extracts the desired json field name from a "json" struct tag. The form of these struct tags is "[<name>][,<options>]".
+// jsonFieldNameFromTag extracts the desired json field name from a "json" struct tag. The form of these struct tags is "[<name>][,<options>]". The name part never contains a ",".
 // This function returns the name part if it is present, else an empty string.
 func jsonFieldNameFromTag(tag string) string {
 	commaPosition := strings.Index(tag, ",")

--- a/internal/jsonfieldnames/extract.go
+++ b/internal/jsonfieldnames/extract.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 )
 
-// Extract extracts JSON field names from a struct value or a pointer to a struct value. If the value passed to Extract is nil,
-// is not a struct value or a pointer to a struct value, an error is returned instead.
+// Extract extracts JSON field names from a struct value or a pointer to a struct value. If the value passed to Extract is either nil
+// or is not a struct value or a pointer to a struct value, an error is returned instead.
 func Extract(value interface{}) ([]string, error) {
 	typ := reflect.TypeOf(value)
 	if typ == nil {

--- a/internal/jsonfieldnames/extract.go
+++ b/internal/jsonfieldnames/extract.go
@@ -1,0 +1,98 @@
+// Package jsonfieldnames contains a function to extract JSON field names from a value.
+//
+// In addition to their fixed, hardcoded members, business objects for energy marshal additional values into Geschaeftsobjekt.ExtensionData.
+// As Go's standard library JSON package has no option for a kitchen sink field accepting all remaining JSON fields,
+// there are two passes of unmarshaling: Once into the struct, once into a generic map. To avoid duplicates in the struct and the map,
+// fields that can be found in the struct are removed from the map. This package provides a mechanism to extract the names of
+// these fields in a generic way.
+package jsonfieldnames
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// Extract extracts JSON field names from a struct value or a pointer to a struct value. If the value passed to Extract is nil,
+// is not a struct value or a pointer to a struct value, an error is returned instead.
+func Extract(value interface{}) ([]string, error) {
+	typ := reflect.TypeOf(value)
+	if typ == nil {
+		return nil, fmt.Errorf("cannot extract field names: value is nil")
+	}
+
+	// When value is a pointer, dereference the type, but keep the original type to be used in the error message
+	// in case the dereferenced type is also invalid.
+	originalTyp := typ
+
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+
+	if typ.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("cannot extract field names: value must either be struct nor pointer to a struct, but is %s", originalTyp.String())
+	}
+
+	return extractFromStruct(typ), nil
+}
+
+// extractFromStruct extracts the JSON field names from a struct type. Panics if typ is not a struct type.
+func extractFromStruct(typ reflect.Type) []string {
+	fieldNames := make([]string, 0)
+	fieldCount := typ.NumField()
+
+	// Cycle through all the fields and merge the JSON field names extracted from every field.
+	for i := 0; i < fieldCount; i++ {
+		field := typ.Field(i)
+		fieldNames = append(fieldNames, extractFromField(field)...)
+	}
+
+	return fieldNames
+}
+
+// extractFromField extracts the JSON field names from a struct field. A single field can provide from zero to many JSON field names,
+// because embedded structs are also fields and may contain an arbitrary count of fields themselves.
+func extractFromField(field reflect.StructField) []string {
+	jsonTag := field.Tag.Get("json")
+
+	// If the json tag equals "-", it should not be included at all in the payload.
+	if jsonTag == "-" {
+		return fieldNames()
+	}
+
+	jsonFieldName := jsonFieldNameFromTag(jsonTag)
+
+	switch {
+
+	// field is explicitly given a JSON field name via struct tag.
+	case jsonFieldName != "":
+		return fieldNames(jsonFieldName)
+
+	// field is an embedded struct without explicit JSON field name. That means its fields are merged into the embedding struct.
+	case jsonFieldName == "" && field.Anonymous && field.Type.Kind() == reflect.Struct:
+		return extractFromStruct(field.Type)
+
+	// field is an embedded struct pointer without explicit JSON field name. That means its fields are merged into the embedding struct.
+	case jsonFieldName == "" && field.Anonymous && field.Type.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.Struct:
+		return extractFromStruct(field.Type.Elem())
+
+	// field has no explicit JSON field name, so use the field name instead. Both non-embedded fields and embedded fields that are neither
+	// structs nor pointers to structs are handled this way.
+	default:
+		return fieldNames(field.Name)
+	}
+}
+
+// jsonFieldNameFromTag extracts the desired json field name from a "json" struct tag. The form of these struct tags is "[<name>][,<options>]".
+// This function returns the name part if it is present, else an empty string.
+func jsonFieldNameFromTag(tag string) string {
+	commaPosition := strings.Index(tag, ",")
+	if commaPosition == -1 {
+		return tag
+	}
+	return tag[:commaPosition]
+}
+
+func fieldNames(names ...string) []string {
+	return names
+}

--- a/internal/jsonfieldnames/extract.go
+++ b/internal/jsonfieldnames/extract.go
@@ -84,7 +84,7 @@ func extractFromField(field reflect.StructField) []string {
 }
 
 // jsonFieldNameFromTag extracts the desired json field name from a "json" struct tag. The form of these struct tags is "[<name>][,<options>]". The name part never contains a ",".
-// This function returns the name part if it is present, else an empty string.
+// This function returns the name part if it is present or an empty string otherwise.
 func jsonFieldNameFromTag(tag string) string {
 	commaPosition := strings.Index(tag, ",")
 	if commaPosition == -1 {

--- a/internal/jsonfieldnames/extract.go
+++ b/internal/jsonfieldnames/extract.go
@@ -18,7 +18,7 @@ import (
 func Extract(value interface{}) ([]string, error) {
 	typ := reflect.TypeOf(value)
 	if typ == nil {
-		return nil, fmt.Errorf("cannot extract field names: value is nil")
+		return nil, fmt.Errorf("cannot extract field names: typ is nil")
 	}
 
 	// When value is a pointer, dereference the type, but keep the original type to be used in the error message

--- a/internal/jsonfieldnames/extract_test.go
+++ b/internal/jsonfieldnames/extract_test.go
@@ -1,0 +1,162 @@
+package jsonfieldnames_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/corbym/gocrest/is"
+	"github.com/corbym/gocrest/then"
+	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
+)
+
+func TestExtractFromInvalidTypes(t *testing.T) {
+	t.Parallel()
+
+	var stringValue string = "foobar"
+	var intValue int = 42
+	var boolValue bool = true
+
+	inputs := map[string]interface{}{
+		"nil":               nil,
+		"string":            stringValue,
+		"int":               intValue,
+		"bool":              boolValue,
+		"pointer to string": &stringValue,
+		"pointer to int":    &intValue,
+		"pointer to bool":   &boolValue,
+	}
+
+	for name := range inputs {
+		input := inputs[name]
+
+		t.Run(
+			name,
+			func(t *testing.T) {
+				fields, err := jsonfieldnames.Extract(input)
+
+				then.AssertThat(t, fields, is.Nil())
+				then.AssertThat(t, err, is.Not(is.Nil()))
+			},
+		)
+	}
+}
+
+func TestExtractFromValidTypes(t *testing.T) {
+	t.Parallel()
+
+	testcases := map[string]struct {
+		// input is the value that JSON field names are extracted from.
+		input interface{}
+
+		// expectedFields are the fields that we expected to be extracted, in alphabetical order.
+		expectedFields []string
+	}{
+		"struct with no fields": {
+			input:          struct{}{},
+			expectedFields: []string{},
+		},
+		"struct with fields w/o tags": {
+			input: struct {
+				Foo int
+				Bar int
+			}{},
+			expectedFields: []string{"Bar", "Foo"},
+		},
+		"struct with fields with simple tags": {
+			input: struct {
+				Foo int `json:"foo"`
+				Bar int `json:"bar"`
+			}{},
+			expectedFields: []string{"bar", "foo"},
+		},
+		"struct with fields that should be ignored by json package": {
+			input: struct {
+				Foo int `json:"-"`
+				Bar int `json:"-"`
+			}{},
+			expectedFields: []string{},
+		},
+		"struct with fields that have additional options": {
+			input: struct {
+				Foo  int `json:"boo,omitempty"`
+				Bar  int `json:"far,"`
+				Baz  int `json:",omitempty"`
+				Dash int `json:"-,"`
+			}{},
+			expectedFields: []string{"-", "Baz", "boo", "far"},
+		},
+		"pointer to struct": {
+			input: &struct {
+				XYZ int `json:"xyz"`
+			}{},
+			expectedFields: []string{"xyz"},
+		},
+		"struct with embedded structs w/o explit JSON name": {
+			input: struct {
+				embeddedStructHello
+				embeddedStructWorld `json:",omitempty"`
+			}{},
+			expectedFields: []string{"hello", "world"},
+		},
+		"struct with pointers to embedded structs w/o explicit JSON name": {
+			input: struct {
+				*embeddedStructHello
+				*embeddedStructWorld `json:",omitempty"`
+			}{},
+			expectedFields: []string{"hello", "world"},
+		},
+		"struct with embedded structs with tags": {
+			input: struct {
+				embeddedStructHello `json:"embed_1"`
+				embeddedStructWorld `json:"embed_2,omitempty"`
+			}{},
+			expectedFields: []string{"embed_1", "embed_2"},
+		},
+		"struct with embedded non-structs": {
+			input: struct {
+				EmbeddedString
+				EmbeddedInt
+				EmbeddedBool
+				EmbeddedInterface
+			}{},
+			expectedFields: []string{"EmbeddedBool", "EmbeddedInt", "EmbeddedInterface", "EmbeddedString"},
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+
+		t.Run(
+			name,
+			func(t *testing.T) {
+				fields, err := jsonfieldnames.Extract(testcase.input)
+				sort.Strings(fields)
+
+				then.AssertThat(t, fields, is.EqualTo(testcase.expectedFields))
+				then.AssertThat(t, err, is.Nil())
+			},
+		)
+	}
+}
+
+// embeddedStructHello is used as embedded struct in TestExtractFromValidTypes.
+type embeddedStructHello struct {
+	Hello string `json:"hello"`
+}
+
+// embeddedStructWorld is used as embedded struct in TestExtractFromValidTypes.
+type embeddedStructWorld struct {
+	World string `json:"world"`
+}
+
+// EmbeddedString is used as embedded type in TestExtractFromValidTypes.
+type EmbeddedString string
+
+// EmbeddedInt is used as embedded type in TestExtractFromValidTypes.
+type EmbeddedInt int
+
+// EmbeddedBool is used as embedded type in TestExtractFromValidTypes.
+type EmbeddedBool bool
+
+// EmbeddedInterface is used as embedded type in TestExtractFromValidTypes.
+type EmbeddedInterface interface{}


### PR DESCRIPTION
This introduces an internal package (i.e. not part of the API exposed to consumers of this package) that provides a mechanism to extract the JSON field names from a struct value via reflection. This should ease the pain of #75 a bit.

I also changed working implementations of `GetDefaultJsonTags` to make use of this instead of hardcoding the struct members lists.