### PR TITLE
Use generic function for scan function

### DIFF
--- a/enum/rechnungstyp/rechnungstyp.go
+++ b/enum/rechnungstyp/rechnungstyp.go
@@ -3,6 +3,8 @@ package rechnungstyp
 import (
 	"database/sql/driver"
 	"fmt"
+
+	"github.com/hochfrequenz/go-bo4e/internal/dbScanValue"
 )
 
 // Rechnungstyp ist eine Abbildung verschiedener Rechnungstypen zur Kennzeichnung von bo.Rechnung en
@@ -37,16 +39,10 @@ func (r Rechnungstyp) Value() (driver.Value, error) {
 
 // Scan - Implement sql scanner interface to read the json representation from the DB
 func (r *Rechnungstyp) Scan(value interface{}) error {
-	// if value is nil, false
-	if value == nil || value.(*string) == nil {
-		// set the value of the pointer to 0 as default
-		*r = 0
-		return nil
+	v, err := dbScanValue.GetValueFromDB[Rechnungstyp](value, _RechnungstypNameToValue)
+	if err != nil {
+		return err
 	}
-	s := *value.(*string)
-	if v, ok := _RechnungstypNameToValue[s]; ok {
-		*r = v
-		return nil
-	}
-	return fmt.Errorf("could not read %s", s)
+	*r = v
+	return nil
 }

--- a/internal/dbScanValue/db_scan_value.go
+++ b/internal/dbScanValue/db_scan_value.go
@@ -1,0 +1,27 @@
+package dbScanValue
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// This can be used from golang 1.18 on
+func GetValueFromDB[E](dbValue interface{}, mapping map[string]E) (*E, error) {
+	if v, ok := mapping[GetStringFromDB(dbValue)]; ok {
+		return &v, nil
+	}
+	return nil, fmt.Errorf("could not read %s", GetStringFromDB(dbValue))
+}
+
+func GetStringFromDB(dbValue interface{}) string {
+	var value string
+	if reflect.ValueOf(dbValue).Kind() == reflect.Ptr {
+		if dbValue == nil || dbValue.(*string) == nil {
+			return ""
+		}
+		value = *dbValue.(*string)
+	} else {
+		value = dbValue.(string)
+	}
+	return value
+}


### PR DESCRIPTION
A generic function reduces the boilerplate when adding the scan function to all enums. Since this needs golang 1.18 we postpone this to a later point