### PR TITLE
Add GetAll and GetSingle

### DIFF
--- a/market_communication/boney_comb_stammdaten.go
+++ b/market_communication/boney_comb_stammdaten.go
@@ -75,3 +75,23 @@ func GetAll[T any, Ptr interface {
 
 	return result
 }
+
+// GetSingle searches BOneyComb's Stammdaten for the single business object of the specified type, given as type parameter T.
+// T must be non-pointer type, even if bo.BusinessObject is implemented only via pointer receivers (*T). Returns an error
+// if there is either no business object of that type or there is more than one.
+func GetSingle[T any, Ptr interface {
+	bo.BusinessObject
+	*T
+}](boneyComb *BOneyComb) (*T, error) {
+	all := GetAll[T, Ptr](boneyComb)
+
+	if len(all) == 0 {
+		return nil, fmt.Errorf("there is no business object with the given type")
+	}
+
+	if len(all) > 1 {
+		return nil, fmt.Errorf("there is more than one (%d) business object with the given type", len(all))
+	}
+
+	return all[0], nil
+}

--- a/market_communication/boney_comb_stammdaten.go
+++ b/market_communication/boney_comb_stammdaten.go
@@ -2,6 +2,7 @@ package market_communication
 
 import (
 	"fmt"
+
 	"github.com/hochfrequenz/go-bo4e/bo"
 	"github.com/hochfrequenz/go-bo4e/enum/botyp"
 )
@@ -52,4 +53,25 @@ func (boneyComb *BOneyComb) GetSingle(typ botyp.BOTyp) (bo.BusinessObject, error
 		return nil, fmt.Errorf("There is more than one (%d) business object with type {%v}", len(allBOsOfType), typ)
 	}
 	return allBOsOfType[0], nil
+}
+
+// GetAll filters a BOneyComb's Stammdaten for business objects of a specific type, given as type parameter T. T must be a non-pointer type,
+// even if bo.BusinessObject is implemented only via pointer receivers (*T).
+func GetAll[T any, Ptr interface {
+	bo.BusinessObject
+	*T
+}](boneyComb *BOneyComb) []*T {
+	result := make([]*T, 0)
+
+	for _, businessObject := range boneyComb.Stammdaten {
+		if convertedBusinessObject, ok := businessObject.(T); ok {
+			result = append(result, &convertedBusinessObject)
+		}
+
+		if convertedBusinessObject, ok := businessObject.(Ptr); ok {
+			result = append(result, (*T)(convertedBusinessObject))
+		}
+	}
+
+	return result
 }

--- a/market_communication/boney_comb_stammdaten_get_all_example_test.go
+++ b/market_communication/boney_comb_stammdaten_get_all_example_test.go
@@ -1,0 +1,41 @@
+package market_communication_test
+
+import (
+	"fmt"
+
+	"github.com/hochfrequenz/go-bo4e/bo"
+	"github.com/hochfrequenz/go-bo4e/enum/botyp"
+	"github.com/hochfrequenz/go-bo4e/market_communication"
+)
+
+func ExampleGetAll() {
+	boneyComb := &market_communication.BOneyComb{
+		Stammdaten: []bo.BusinessObject{
+			bo.NewBusinessObject(botyp.MARKTTEILNEHMER),
+			bo.NewBusinessObject(botyp.MESSLOKATION),
+			bo.NewBusinessObject(botyp.ZAEHLER),
+			bo.NewBusinessObject(botyp.RECHNUNG),
+			bo.NewBusinessObject(botyp.MESSLOKATION),
+			bo.NewBusinessObject(botyp.LASTGANG),
+
+			// Business objects created via bo.NewBusinessObject are pointers, but the concrete types implement
+			// bo.BusinessObject via value receivers, so a slice of these objects may contain non-pointer values
+			// as well. We include one of them here to show that these work as expected, too.
+			bo.Marktteilnehmer{},
+		},
+	}
+
+	var preisblattValues []*bo.Preisblatt = market_communication.GetAll[bo.Preisblatt](boneyComb)
+	fmt.Printf("objects of type Preisblatt     : %d\n", len(preisblattValues))
+
+	var marktteilnehmerValues []*bo.Marktteilnehmer = market_communication.GetAll[bo.Marktteilnehmer](boneyComb)
+	fmt.Printf("objects of type Marktteilnehmer: %d\n", len(marktteilnehmerValues))
+
+	var lastgangValues []*bo.Lastgang = market_communication.GetAll[bo.Lastgang](boneyComb)
+	fmt.Printf("objects of type Lastgang       : %d\n", len(lastgangValues))
+
+	// Output:
+	// objects of type Preisblatt     : 0
+	// objects of type Marktteilnehmer: 2
+	// objects of type Lastgang       : 1
+}

--- a/market_communication/boney_comb_stammdaten_get_single_example_test.go
+++ b/market_communication/boney_comb_stammdaten_get_single_example_test.go
@@ -1,0 +1,56 @@
+package market_communication_test
+
+import (
+	"fmt"
+
+	"github.com/hochfrequenz/go-bo4e/bo"
+	"github.com/hochfrequenz/go-bo4e/enum/botyp"
+	"github.com/hochfrequenz/go-bo4e/market_communication"
+)
+
+func ExampleGetSingle() {
+	boneyComb := &market_communication.BOneyComb{
+		Stammdaten: []bo.BusinessObject{
+			bo.NewBusinessObject(botyp.MARKTTEILNEHMER),
+			bo.NewBusinessObject(botyp.MESSLOKATION),
+			bo.NewBusinessObject(botyp.ZAEHLER),
+			bo.NewBusinessObject(botyp.RECHNUNG),
+			bo.NewBusinessObject(botyp.MESSLOKATION),
+			bo.NewBusinessObject(botyp.LASTGANG),
+
+			// Business objects created via bo.NewBusinessObject are pointers, but the concrete types implement
+			// bo.BusinessObject via value receivers, so a slice of these objects may contain non-pointer values
+			// as well. We include one of them here to show that these work as expected, too.
+			bo.Marktteilnehmer{},
+		},
+	}
+
+	preisblatt, err := market_communication.GetSingle[bo.Preisblatt](boneyComb)
+	if err != nil {
+		fmt.Println("Preisblatt count is not 1")
+	}
+	if preisblatt != nil {
+		fmt.Println("found a Preisblatt")
+	}
+
+	marktteilnehmer, err := market_communication.GetSingle[bo.Marktteilnehmer](boneyComb)
+	if err != nil {
+		fmt.Println("Marktteilnehmer count is not 1")
+	}
+	if marktteilnehmer != nil {
+		fmt.Println("found a Marktteilnehmer")
+	}
+
+	lastgang, err := market_communication.GetSingle[bo.Lastgang](boneyComb)
+	if err != nil {
+		fmt.Println("Lastgang count is not 1")
+	}
+	if lastgang != nil {
+		fmt.Println("found a Lastgang")
+	}
+
+	// Output:
+	// Preisblatt count is not 1
+	// Marktteilnehmer count is not 1
+	// found a Lastgang
+}


### PR DESCRIPTION
This PR implements `GetAll` and `GetSingle` as envisioned in #168 - I hope it's fine. Instead of unit tests I went the route of providing testable examples which also serve as additional documentation.

To be honest, I'm not entirely convinced this is a good addition, as it is possible to write [a fully generic function extracting both values and pointers from a slice](https://go.dev/play/p/zPGYKGVTyox), so the same functionality could be provided by a generics utility package.