### PR TITLE
DEV-18763: Expand unmapped data support to BO Marktlokation and COM Zaehlwerk

### DIFF
--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -22,6 +22,7 @@ import (
 
 // Marktlokation contains information about a market location aka "MaLo"
 type Marktlokation struct {
+	unmappeddatamarshaller.ExtensionData
 	Geschaeftsobjekt
 	MarktlokationsId     string                                    `json:"marktlokationsId,omitempty" example:"12345678913" validate:"required,numeric,len=11,maloid"` // MarktlokationsId is the ID of the market location
 	Sparte               sparte.Sparte                             `json:"sparte,omitempty" validate:"required"`                                                       // Sparte describes the Division

--- a/bo/marktlokation_test.go
+++ b/bo/marktlokation_test.go
@@ -104,7 +104,10 @@ func (s *Suite) Test_Marktlokation_Deserialization() {
 	var deserializedMalo bo.Marktlokation
 	err = json.Unmarshal(serializedMalo, &deserializedMalo)
 	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedMalo, is.EqualTo(malo))
+
+	expectedJson, _ := json.Marshal(malo)
+	actualJson, _ := json.Marshal(deserializedMalo)
+	then.AssertThat(s.T(), expectedJson, is.EqualTo(actualJson))
 }
 
 //nolint:dupl // This can only be simplified if we use generics. anything else seems overly complicated but maybe it's just me
@@ -165,7 +168,7 @@ func (s *Suite) Test_Marktlokation_DeSerialization_With_Unkonwn_Fields() {
 	// unmarshalling tests
 	err := json.Unmarshal([]byte(maloJsonWithUnknownFields), &malo)
 	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), malo.Geschaeftsobjekt.ExtensionData, is.Not(is.Nil()))
+	then.AssertThat(s.T(), malo.ExtensionData, is.Not(is.Nil()))
 	then.AssertThat(s.T(), malo.Zaehlwerke, is.Not(is.Nil()))                // marktloktion->zaehlwerke is NOT part of the bo4e standard ==> present in extension data
 	then.AssertThat(s.T(), malo.ExtensionData["marktlokationsId"], is.Nil()) // marktlokation->marklokationsId is part of the bo4e standard ==> not present in extension data
 	then.AssertThat(s.T(), malo.MarktlokationsId, is.EqualTo("10024073272")) // but where it should be

--- a/com/zaehlwerk.go
+++ b/com/zaehlwerk.go
@@ -1,17 +1,20 @@
 package com
 
 import (
+	"encoding/json"
 	"github.com/hochfrequenz/go-bo4e/enum/energierichtung"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/schwachlastfaehigkeit"
 	"github.com/hochfrequenz/go-bo4e/enum/unterbrechbarkeit"
 	"github.com/hochfrequenz/go-bo4e/enum/verbrauchsart"
 	"github.com/hochfrequenz/go-bo4e/enum/waermenutzung"
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
 )
 
 // A Zaehlwerk is the counting part of a meter. A meter consists of one or more Zaehlwerke
 type Zaehlwerk struct {
+	unmappeddatamarshaller.ExtensionData
 	ZaehlwerkId       string                               `json:"zaehlwerkId,omitempty" validate:"required" example:"47110815_1"`          // ZaehlwerkId ist die Identifikation des Zählwerks (Registers) innerhalb des Zählers. Oftmals eine laufende Nummer hinter der Zählernummer.
 	Bezeichnung       string                               `json:"bezeichnung,omitempty" validate:"required" example:"Zählwerk_Wirkarbeit"` // Bezeichnung ist eine zusätzliche Bezeichnung
 	Richtung          energierichtung.Energierichtung      `json:"richtung,omitempty" validate:"required"`                                  // Richtung beschreibt die Energierichtung: Einspeisung oder Ausspeisung.
@@ -34,4 +37,24 @@ type Zaehlwerk struct {
 	// the json tag is different from the field name ("zaehlzeiten" instead of "zaehlzeit") to be consistent with the C# lib: https://github.com/Hochfrequenz/BO4E-dotnet/issues/249
 	Zaehlzeit     *Zaehlzeit `json:"zaehlzeiten,omitempty"`
 	Konfiguration *string    `json:"konfiguration,omitempty"`
+}
+
+func (zw *Zaehlwerk) UnmarshalJSON(bytes []byte) (err error) {
+	if zw.ExtensionData == nil {
+		zw.ExtensionData = map[string]any{}
+	}
+	return unmappeddatamarshaller.UnmarshallWithUnmappedData(zw, &zw.ExtensionData, bytes)
+}
+
+// This shadow type is necessary to prevent a deadlock in json.Marshal
+type zaehlwerkForMarshal Zaehlwerk
+
+//nolint:dupl // This can only be simplified if we use generics. anything else seems overly complicated but maybe it's just me
+func (zw Zaehlwerk) MarshalJSON() (bytes []byte, err error) {
+	s := zaehlwerkForMarshal(zw)
+	byteArr, err := json.Marshal(s)
+	if err != nil {
+		return
+	}
+	return unmappeddatamarshaller.HandleUnmappedDataPropertyMarshalling(byteArr)
 }


### PR DESCRIPTION
The `Marktlokation` and `Zaehlwerk` structs were adjusted to correctly handle unmapped data fields in un-/marshalling operations.