### PR TITLE
Feature: adresse.Ortsteil

### DIFF
--- a/com/adresse.go
+++ b/com/adresse.go
@@ -9,6 +9,7 @@ import (
 type Adresse struct {
 	Postleitzahl string                 `json:"postleitzahl,omitempty" example:"82031" validate:"numeric,required"` // Postleitzahl is the zip code, mandatory
 	Ort          string                 `json:"ort,omitempty" example:"Grünwald" validate:"alphaunicode,required"`  // Ort is the city name, mandatory
+	Ortsteil     string                 `json:"ortsteil,omitempty" example:"Geiselgasteig"`                         // Ortsteil is the city part, optional
 	Strasse      string                 `json:"strasse,omitempty" example:"Nördliche Münchner Straße 27A"`          // Strasse is the street name
 	Hausnummer   string                 `json:"hausnummer,omitempty" example:"27A"`                                 // Hausnummer is the house number including suffixes like "a" or "-1"
 	Postfach     string                 `json:"postfach,omitempty"`                                                 // Postfach is a post box

--- a/com/adresse.go
+++ b/com/adresse.go
@@ -20,7 +20,7 @@ type Adresse struct {
 // AdresseStructLevelValidation does a cross check on a Adresse object
 func AdresseStructLevelValidation(sl validator.StructLevel) {
 	// ToDo: use required_without/required_if instead of own validator
-	// see https://github.com/go-playground/validator/v10/search?q=required_without
+	// see https://pkg.go.dev/github.com/go-playground/validator/v10#hdr-Required_Without
 	address := sl.Current().Interface().(Adresse)
 	if (len(address.Strasse) == 0 && len(address.Postfach) == 0) || (len(address.Strasse) > 0 && len(address.Postfach) > 0) {
 		sl.ReportError(address.Strasse, "Strasse", "Postfach", "StrasseXORPostfach", "")

--- a/com/adresse_test.go
+++ b/com/adresse_test.go
@@ -2,8 +2,9 @@ package com_test
 
 import (
 	"encoding/json"
-	"github.com/hochfrequenz/go-bo4e/internal"
 	"strings"
+
+	"github.com/hochfrequenz/go-bo4e/internal"
 
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
@@ -17,6 +18,7 @@ func (s *Suite) Test_Address_Deserialization() {
 	var adresse = com.Adresse{
 		Postleitzahl: "82031",
 		Ort:          "Grünwald",
+		Ortsteil:     "Geiselgasteig",
 		Strasse:      "Nördlicher Münchner Straße",
 		Hausnummer:   "27A",
 		Landescode:   internal.Ptr(landescode.DE),

--- a/com/adresse_test.go
+++ b/com/adresse_test.go
@@ -2,6 +2,7 @@ package com_test
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/hochfrequenz/go-bo4e/internal"
@@ -25,8 +26,8 @@ func (s *Suite) Test_Address_Deserialization() {
 	}
 	serializedAdresse, err := json.Marshal(adresse)
 	jsonString := string(serializedAdresse)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "DE"), is.True())  // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "61"), is.False()) // no "61" for DE
+	then.AssertThat(s.T(), strings.Contains(jsonString, "DE"), is.True())                              // stringified enum
+	then.AssertThat(s.T(), strings.Contains(jsonString, strconv.Itoa(int(landescode.DE))), is.False()) // no raw int enum value
 	then.AssertThat(s.T(), err, is.Nil())
 	then.AssertThat(s.T(), serializedAdresse, is.Not(is.NilArray[byte]()))
 	var deserializedAdresse com.Adresse


### PR DESCRIPTION
`adresse.Ortsteil` is already part of the .NET BO4E library: [Adresse.cs, line 98](https://github.com/Hochfrequenz/BO4E-dotnet/blob/v0.2.109/BO4E/COM/Adresse.cs#L98).
To be consistent with other optional string values like `Adresszusatz` and `CoErgaenzung`, it is a string, not a pointer to a string.

In addition, a 404 link in the documentation was changed.

Also in addition, the test that verifies that the country code is not marshaled as an integer now checks against the numeric value of the constant instead of a hardcoded value. There already was a mismatch (check was against `61`, but DE country code is `62`).