### PR TITLE
More consistent nullables. 

### DIFF
--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -2,11 +2,12 @@ package bo
 
 import (
 	"encoding/json"
+	"regexp"
+
 	"github.com/hochfrequenz/go-bo4e/enum/messtechnischeeinordnung"
 	"github.com/hochfrequenz/go-bo4e/enum/sperrstatus"
 	"github.com/hochfrequenz/go-bo4e/enum/zeitreihentyp"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
-	"regexp"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
@@ -24,20 +25,20 @@ import (
 type Marktlokation struct {
 	unmappeddatamarshaller.ExtensionData
 	Geschaeftsobjekt
-	MarktlokationsId     string                                    `json:"marktlokationsId,omitempty" example:"12345678913" validate:"required,numeric,len=11,maloid"` // MarktlokationsId is the ID of the market location
-	Sparte               sparte.Sparte                             `json:"sparte,omitempty" validate:"required"`                                                       // Sparte describes the Division
-	Energierichtung      energierichtung.Energierichtung           `json:"energierichtung,omitempty" validate:"required"`                                              // Energierichtung describes whether energy is supplied out of or fed into the grid.
-	Bilanzierungsmethode bilanzierungsmethode.Bilanzierungsmethode `json:"bilanzierungsmethode,omitempty" validate:"required"`                                         // Bilanzierungsmethode is the accounting method
-	Verbrauchsart        verbrauchsart.Verbrauchsart               `json:"verbrauchsart,omitempty"`                                                                    // Verbrauchsart is the consumption type
-	Unterbrechbar        *bool                                     `json:"unterbrechbar,omitempty"`                                                                    // Unterbrechbar describes whether the supply is interruptible
-	Netzebene            netzebene.Netzebene                       `json:"netzebene,omitempty" validate:"required"`                                                    // Netzebene, in der der Bezug der Energie erfolgt. Bei Strom Spannungsebene der Lieferung, bei Gas Druckstufe.
-	Netzbetreibercodenr  string                                    `json:"netzbetreibercodenr,omitempty" validate:"omitempty,numeric,len=13"`                          // Netzbetreibercodenr is the code number of the "Netzbetreiber"
-	Gebiettyp            gebiettyp.Gebiettyp                       `json:"gebiettyp,omitempty"`                                                                        // Gebiettyp is the type of the "Netzgebiet"
-	Netzgebietnr         string                                    `json:"netzgebietnr,omitempty"`                                                                     // Netzgebietnr is the number of the "Netzgebiet" in the enet database
-	Bilanzierungsgebiet  string                                    `json:"bilanzierungsgebiet,omitempty"`                                                              // Bilanzierungsgebiet, dem das Netzgebiet zugeordnet ist - im Falle eines Strom Netzes.
-	Grundversorgercodenr string                                    `json:"grundversorgercodenr,omitempty" validate:"omitempty,numeric,len=13"`                         // Grundversorgercodenr is the code number of the "Grundversorger" responsible for this market location
-	Gasqualitaet         gasqualitaet.Gasqualitaet                 `json:"gasqualitaet,omitempty"`                                                                     // Gasqualitaet is the gas quality
-	Endkunde             *Geschaeftspartner                        `json:"endkunde,omitempty" validate:"-"`                                                            // Endkunde is the Geschaeftspartner who owns this market location
+	MarktlokationsId     string                                     `json:"marktlokationsId,omitempty" example:"12345678913" validate:"required,numeric,len=11,maloid"` // MarktlokationsId is the ID of the market location
+	Sparte               sparte.Sparte                              `json:"sparte,omitempty" validate:"required"`                                                       // Sparte describes the Division
+	Energierichtung      *energierichtung.Energierichtung           `json:"energierichtung,omitempty" validate:"omitnil,ne=0"`                                          // Energierichtung describes whether energy is supplied out of or fed into the grid.
+	Bilanzierungsmethode *bilanzierungsmethode.Bilanzierungsmethode `json:"bilanzierungsmethode,omitempty" validate:"omitnil,ne=0"`                                     // Bilanzierungsmethode is the accounting method
+	Verbrauchsart        verbrauchsart.Verbrauchsart                `json:"verbrauchsart,omitempty"`                                                                    // Verbrauchsart is the consumption type
+	Unterbrechbar        *bool                                      `json:"unterbrechbar,omitempty"`                                                                    // Unterbrechbar describes whether the supply is interruptible
+	Netzebene            netzebene.Netzebene                        `json:"netzebene,omitempty" validate:"required"`                                                    // Netzebene, in der der Bezug der Energie erfolgt. Bei Strom Spannungsebene der Lieferung, bei Gas Druckstufe.
+	Netzbetreibercodenr  *string                                    `json:"netzbetreibercodenr,omitempty" validate:"omitnil,numeric,len=13"`                            // Netzbetreibercodenr is the code number of the "Netzbetreiber"
+	Gebiettyp            gebiettyp.Gebiettyp                        `json:"gebiettyp,omitempty"`                                                                        // Gebiettyp is the type of the "Netzgebiet"
+	Netzgebietnr         *string                                    `json:"netzgebietnr,omitempty"`                                                                     // Netzgebietnr is the number of the "Netzgebiet" in the enet database
+	Bilanzierungsgebiet  *string                                    `json:"bilanzierungsgebiet,omitempty"`                                                              // Bilanzierungsgebiet, dem das Netzgebiet zugeordnet ist - im Falle eines Strom Netzes.
+	Grundversorgercodenr *string                                    `json:"grundversorgercodenr,omitempty" validate:"omitnil,numeric,len=13"`                           // Grundversorgercodenr is the code number of the "Grundversorger" responsible for this market location
+	Gasqualitaet         gasqualitaet.Gasqualitaet                  `json:"gasqualitaet,omitempty"`                                                                     // Gasqualitaet is the gas quality
+	Endkunde             *Geschaeftspartner                         `json:"endkunde,omitempty" validate:"-"`                                                            // Endkunde is the Geschaeftspartner who owns this market location
 	// only one of the following three optional address attributes can be set
 	Lokationsadresse          *com.Adresse                 `json:"lokationsadresse,omitempty" validate:"required_without_all=Geoadresse Katasterinformation"` // Lokationsadresse is the address at which the energy supply or feed-in takes place
 	Geoadresse                *com.Geokoordinaten          `json:"geoadresse,omitempty" validate:"required_without_all=Lokationsadresse Katasterinformation"` // Geoadresse are the gps coordinates

--- a/bo/marktlokation_test.go
+++ b/bo/marktlokation_test.go
@@ -2,6 +2,9 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -21,8 +24,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"strings"
 )
 
 // Test_Marktlokation_Deserialization tests serialization and deserialization of Marktlokation
@@ -38,16 +39,16 @@ func (s *Suite) Test_Marktlokation_Deserialization() {
 		},
 		MarktlokationsId:     "51238696781",
 		Sparte:               sparte.STROM,
-		Energierichtung:      energierichtung.AUSSP,
-		Bilanzierungsmethode: bilanzierungsmethode.RLM,
+		Energierichtung:      internal.Ptr(energierichtung.AUSSP),
+		Bilanzierungsmethode: internal.Ptr(bilanzierungsmethode.RLM),
 		Verbrauchsart:        verbrauchsart.KL,
 		Unterbrechbar:        &f,
 		Netzebene:            netzebene.MSP,
-		Netzbetreibercodenr:  "0815",
+		Netzbetreibercodenr:  internal.Ptr("0815"),
 		Gebiettyp:            gebiettyp.GRUNDVERSORGUNGSGEBIET,
-		Netzgebietnr:         "1234",
-		Bilanzierungsgebiet:  "Foo",
-		Grundversorgercodenr: "5678",
+		Netzgebietnr:         internal.Ptr("1234"),
+		Bilanzierungsgebiet:  internal.Ptr("Foo"),
+		Grundversorgercodenr: internal.Ptr("5678"),
 		Endkunde: &bo.Geschaeftspartner{
 			Geschaeftsobjekt: bo.Geschaeftsobjekt{
 				BoTyp:             botyp.GESCHAEFTSPARTNER,
@@ -200,8 +201,8 @@ func (s *Suite) Test_Failed_MarktlokationValidation() {
 				},
 				MarktlokationsId:     "",
 				Sparte:               0,
-				Energierichtung:      0,
-				Bilanzierungsmethode: 0,
+				Energierichtung:      internal.Ptr[energierichtung.Energierichtung](0),
+				Bilanzierungsmethode: internal.Ptr[bilanzierungsmethode.Bilanzierungsmethode](0),
 				Netzebene:            0,
 			},
 		},
@@ -217,6 +218,27 @@ func (s *Suite) Test_Failed_MarktlokationValidation() {
 				Katasterinformation: &com.Katasteradresse{
 					GemarkungFlur: "Foo",
 					Flurstueck:    "Bar",
+				},
+			},
+		},
+		"ne": {
+			bo.Marktlokation{
+				Geschaeftsobjekt: bo.Geschaeftsobjekt{
+					BoTyp:             botyp.MARKTLOKATION,
+					VersionStruktur:   "1",
+					ExterneReferenzen: nil,
+				},
+				MarktlokationsId:     "12345678913",
+				Sparte:               sparte.STROM,
+				Energierichtung:      internal.Ptr[energierichtung.Energierichtung](0),
+				Bilanzierungsmethode: internal.Ptr[bilanzierungsmethode.Bilanzierungsmethode](0),
+				Netzebene:            netzebene.NSP,
+				Lokationsadresse: &com.Adresse{
+					Postleitzahl: "82031",
+					Ort:          "Grünwald",
+					Strasse:      "Nördliche Münchner Straße",
+					Hausnummer:   "27A",
+					Landescode:   internal.Ptr(landescode.DE),
 				},
 			},
 		},
@@ -245,9 +267,27 @@ func (s *Suite) Test_Successful_Marktlokation_Validation() {
 			},
 			MarktlokationsId:     "12345678913",
 			Sparte:               sparte.STROM,
-			Energierichtung:      energierichtung.EINSP,
-			Bilanzierungsmethode: bilanzierungsmethode.SLP,
+			Energierichtung:      internal.Ptr(energierichtung.EINSP),
+			Bilanzierungsmethode: internal.Ptr(bilanzierungsmethode.SLP),
 			Netzebene:            netzebene.NSP,
+			Lokationsadresse: &com.Adresse{
+				Postleitzahl: "82031",
+				Ort:          "Grünwald",
+				Strasse:      "Nördliche Münchner Straße",
+				Hausnummer:   "27A",
+				Landescode:   internal.Ptr(landescode.DE),
+			},
+		},
+		// Some nullable values
+		bo.Marktlokation{
+			Geschaeftsobjekt: bo.Geschaeftsobjekt{
+				BoTyp:             botyp.MARKTLOKATION,
+				VersionStruktur:   "1",
+				ExterneReferenzen: nil,
+			},
+			MarktlokationsId: "12345678913",
+			Sparte:           sparte.STROM,
+			Netzebene:        netzebene.NSP,
 			Lokationsadresse: &com.Adresse{
 				Postleitzahl: "82031",
 				Ort:          "Grünwald",

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/corbym/gocrest v1.1.1
-	github.com/go-playground/validator/v10 v10.15.5
+	github.com/go-playground/validator/v10 v10.16.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.15.5 h1:LEBecTWb/1j5TNY1YYG2RcOUN3R7NLylN+x8TTueE24=
 github.com/go-playground/validator/v10 v10.15.5/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
+github.com/go-playground/validator/v10 v10.16.0 h1:x+plE831WK4vaKHO/jpgUGsvLKIqRRkz6M78GuJAfGE=
+github.com/go-playground/validator/v10 v10.16.0/go.mod h1:9iXMNT7sEkjXb0I+enO7QXmzG6QCsPWY4zveKFVRSyU=
 github.com/leodido/go-urn v1.2.4 h1:XlAE/cm/ms7TE/VMVoduSpNBoyc2dOxHs5MZSwAN63Q=
 github.com/leodido/go-urn v1.2.4/go.mod h1:7ZrI8mTSeBSHl/UaRyKQW1qZeMgak41ANeCNaVckg+4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
Related: https://github.com/Hochfrequenz/BO4E-dotnet/pull/168
Makes some fields nullable as is the case with the dotnet library.
Note: This is a **breaking change**.

Motivation: dotnet library seems to serialize a Marktlokation into something like `{ "energierichtung": null }`. On the Go side, this becomes the zero value (`0`), which is in an invalid value for `Energierichtung`. As the JSON unmarshalling checks whether the value is valid, deserialization fails.