### PR TITLE
DEV-44179: Make Menge/Einheit nullable

### DIFF
--- a/bo/bilanzierung_test.go
+++ b/bo/bilanzierung_test.go
@@ -50,11 +50,11 @@ var validBilanzierung = bo.Bilanzierung{
 	Bilanzkreis:         internal.Ptr("11XVE-N-GHM----Q"),
 	Jahresverbrauchsprognose: &com.Menge{
 		Wert:    newDecimalFromString("1500"),
-		Einheit: mengeneinheit.KWH,
+		Einheit: internal.Ptr(mengeneinheit.KWH),
 	},
 	Kundenwert: &com.Menge{
 		Wert:    newDecimalFromString("0.17"),
-		Einheit: mengeneinheit.MWH,
+		Einheit: internal.Ptr(mengeneinheit.MWH),
 	},
 	Verbrauchsaufteilung:      decimal.NewNullDecimal(newDecimalFromString("0.17")),
 	Zeitreihentyp:             zeitreihentyp.LGS,

--- a/bo/rechnung_test.go
+++ b/bo/rechnung_test.go
@@ -388,7 +388,7 @@ var completeValidRechnung = bo.Rechnung{
 			LokationsId:     "54321012345",
 			PositionsMenge: com.Menge{
 				Wert:    decimal.NewFromFloat(20),
-				Einheit: mengeneinheit.KWH,
+				Einheit: internal.Ptr(mengeneinheit.KWH),
 			},
 			Einzelpreis: com.Preis{
 				Wert:       decimal.NewFromFloat(12),

--- a/com/menge.go
+++ b/com/menge.go
@@ -7,6 +7,6 @@ import (
 
 // Menge ist die Abbildung einer Menge mit Wert und Einheit.
 type Menge struct {
-	Wert    decimal.Decimal             `json:"wert" validate:"required"`              // Wert gibt den absoluten Wert der Menge an
-	Einheit mengeneinheit.Mengeneinheit `json:"einheit,omitempty" validate:"required"` // Einheit gibt die Einheit zum jeweiligen Wert an
+	Wert    decimal.Decimal              `json:"wert" validate:"required"`              // Wert gibt den absoluten Wert der Menge an
+	Einheit *mengeneinheit.Mengeneinheit `json:"einheit,omitempty" validate:"required"` // Einheit gibt die Einheit zum jeweiligen Wert an
 }

--- a/com/menge_test.go
+++ b/com/menge_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
+	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"

--- a/com/menge_test.go
+++ b/com/menge_test.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
-	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
+	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
 	"strings"
 )
@@ -15,7 +15,7 @@ import (
 func (s *Suite) Test_Menge_Deserialization() {
 	var menge = com.Menge{
 		Wert:    decimal.NewFromFloat(42),
-		Einheit: mengeneinheit.KUBIKMETER,
+		Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 	}
 	serializedMenge, err := json.Marshal(menge)
 	jsonString := string(serializedMenge)
@@ -34,11 +34,11 @@ func (s *Suite) Test_Successful_Menge_Validation() {
 	validMenges := []interface{}{
 		com.Menge{
 			Wert:    decimal.NewFromFloat(42),
-			Einheit: mengeneinheit.KUBIKMETER,
+			Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 		},
 		com.Menge{
 			Wert:    decimal.NewFromFloat(0), // 0 is a valid value
-			Einheit: mengeneinheit.W,
+			Einheit: internal.Ptr(mengeneinheit.W),
 		},
 	}
 	VerfiySuccessfulValidations(s, validate, validMenges)

--- a/com/netznutzungsabrechnungsdaten_test.go
+++ b/com/netznutzungsabrechnungsdaten_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/artikelidtyp"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungseinheit"
+	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
 )
 
@@ -18,7 +19,7 @@ func (s *Suite) Test_Netznutzungsabrechnungsdaten_Deserialization() {
 	anzahl := 17
 	singulaereBetriebsmittel := com.Menge{
 		Wert:    decimal.NewFromFloat(12.34),
-		Einheit: mengeneinheit.KWH,
+		Einheit: internal.Ptr(mengeneinheit.KWH),
 	}
 	preisSingulaereBetriebsmittel := com.Preis{
 		Wert:    decimal.NewFromFloat(12.34),

--- a/com/rechnungsposition.go
+++ b/com/rechnungsposition.go
@@ -33,7 +33,7 @@ type Rechnungsposition struct {
 // RechnungspositionStructLevelValidation does a cross check on a Rechnungsposition object
 func RechnungspositionStructLevelValidation(sl validator.StructLevel) {
 	rp := sl.Current().Interface().(Rechnungsposition)
-	if rp.Einzelpreis.Bezugswert != rp.PositionsMenge.Einheit {
+	if rp.PositionsMenge.Einheit != nil && rp.Einzelpreis.Bezugswert != *rp.PositionsMenge.Einheit {
 		sl.ReportError(rp.PositionsMenge.Einheit, "Einheit", "PositionsMenge", "PositionsMenge.Einheit==Einzelpreis.Bezugswert", "")
 	}
 	expectedTeilsummeNetto := Menge{
@@ -41,7 +41,7 @@ func RechnungspositionStructLevelValidation(sl validator.StructLevel) {
 		Einheit: rp.PositionsMenge.Einheit,
 	}
 	if rp.ZeitbezogeneMenge != nil {
-		if rp.ZeitbezogeneMenge.Einheit != rp.Einzelpreis.Bezugswert {
+		if rp.ZeitbezogeneMenge.Einheit != nil && *rp.ZeitbezogeneMenge.Einheit != rp.Einzelpreis.Bezugswert {
 			sl.ReportError(rp.ZeitbezogeneMenge.Einheit, "Einheit", "ZeitbezogeneMenge", "ZeitbezogeneMenge.Einheit==Einzelpreis.Bezugswert", "")
 			// further checks are not meaningful at this point because there is no implicit conversion like: "1 year = 12 months"
 			return

--- a/com/rechnungsposition_test.go
+++ b/com/rechnungsposition_test.go
@@ -35,11 +35,11 @@ func (s *Suite) Test_Rechnungsposition_Deserialization() {
 		LokationsId:     "54321012345",
 		PositionsMenge: com.Menge{
 			Wert:    newDecimalFromString("20"),
-			Einheit: mengeneinheit.KWH,
+			Einheit: internal.Ptr(mengeneinheit.KWH),
 		},
 		ZeitbezogeneMenge: &com.Menge{
 			Wert:    newDecimalFromString("23"),
-			Einheit: mengeneinheit.KUBIKMETER,
+			Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 		},
 		Korrekturfaktor: &korrekturfaktor,
 		Einzelpreis: com.Preis{
@@ -98,7 +98,7 @@ func (s *Suite) Test_Failed_RechnungspositionValidation() {
 		"PositionsMenge.Einheit==Einzelpreis.Bezugswert": {
 			com.Rechnungsposition{
 				PositionsMenge: com.Menge{
-					Einheit: mengeneinheit.KW,
+					Einheit: internal.Ptr(mengeneinheit.KW),
 				},
 				Einzelpreis: com.Preis{
 					Bezugswert: mengeneinheit.KUBIKMETER,
@@ -108,13 +108,13 @@ func (s *Suite) Test_Failed_RechnungspositionValidation() {
 		"ZeitbezogeneMenge.Einheit==Einzelpreis.Bezugswert": {
 			com.Rechnungsposition{
 				PositionsMenge: com.Menge{
-					Einheit: mengeneinheit.KW,
+					Einheit: internal.Ptr(mengeneinheit.KW),
 				},
 				Einzelpreis: com.Preis{
 					Bezugswert: mengeneinheit.KW,
 				},
 				ZeitbezogeneMenge: &com.Menge{
-					Einheit: mengeneinheit.KUBIKMETER,
+					Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 				},
 			},
 		},
@@ -122,7 +122,7 @@ func (s *Suite) Test_Failed_RechnungspositionValidation() {
 			com.Rechnungsposition{
 				PositionsMenge: com.Menge{
 					Wert:    decimal.NewFromFloat(10),
-					Einheit: mengeneinheit.KWH,
+					Einheit: internal.Ptr(mengeneinheit.KWH),
 				},
 				Einzelpreis: com.Preis{
 					Wert:       decimal.NewFromFloat(1.5),
@@ -131,7 +131,7 @@ func (s *Suite) Test_Failed_RechnungspositionValidation() {
 				},
 				ZeitbezogeneMenge: &com.Menge{
 					Wert:    decimal.NewFromFloat(3),
-					Einheit: mengeneinheit.KWH,
+					Einheit: internal.Ptr(mengeneinheit.KWH),
 				},
 				TeilsummeNetto: com.Betrag{
 					Wert:     decimal.NewFromFloat(44), // expected 45 = 3*1.5*10 => validation error
@@ -158,7 +158,7 @@ func (s *Suite) Test_Successful_RechnungspositionValidation() {
 			LokationsId:     "54321012345",
 			PositionsMenge: com.Menge{
 				Wert:    decimal.NewFromFloat(20),
-				Einheit: mengeneinheit.KWH,
+				Einheit: internal.Ptr(mengeneinheit.KWH),
 			},
 			Einzelpreis: com.Preis{
 				Wert:       decimal.NewFromFloat(12),

--- a/com/vertragsteil_test.go
+++ b/com/vertragsteil_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
+	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
 	"strings"
 	"time"
@@ -20,15 +21,15 @@ func (s *Suite) Test_Vertragsteil_Deserialization() {
 		Lokation:           "DE0123456789012345678901234567890",
 		VertraglichFixierteMenge: &com.Menge{
 			Wert:    decimal.NewFromFloat(42),
-			Einheit: mengeneinheit.KUBIKMETER,
+			Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 		},
 		MinimaleAbnahmemenge: &com.Menge{
 			Wert:    decimal.NewFromFloat(17),
-			Einheit: mengeneinheit.MW,
+			Einheit: internal.Ptr(mengeneinheit.MW),
 		},
 		MaximaleAbnahmemenge: &com.Menge{
 			Wert:    decimal.NewFromFloat(-3),
-			Einheit: mengeneinheit.MONAT,
+			Einheit: internal.Ptr(mengeneinheit.MONAT),
 		},
 	}
 	serializedVertragsteil, err := json.Marshal(vertraqsteil)

--- a/com/vertragsteil_test.go
+++ b/com/vertragsteil_test.go
@@ -98,15 +98,15 @@ func (s *Suite) Test_Successful_Vertragsteil_Validation() {
 			Lokation:           "DE0123456789012345678901234567890",
 			VertraglichFixierteMenge: &com.Menge{
 				Wert:    decimal.NewFromFloat(42),
-				Einheit: mengeneinheit.KUBIKMETER,
+				Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 			},
 			MinimaleAbnahmemenge: &com.Menge{
 				Wert:    decimal.NewFromFloat(17),
-				Einheit: mengeneinheit.MW,
+				Einheit: internal.Ptr(mengeneinheit.MW),
 			},
 			MaximaleAbnahmemenge: &com.Menge{
 				Wert:    decimal.NewFromFloat(-3),
-				Einheit: mengeneinheit.MONAT,
+				Einheit: internal.Ptr(mengeneinheit.MONAT),
 			},
 		},
 		com.Vertragsteil{


### PR DESCRIPTION
Although I'd prefer to have something like `1` as Einheit rather than null but this way it's consistent with BO4E.net
