### PR TITLE
Remove suite package

### DIFF
--- a/bo/ansprechpartner_test.go
+++ b/bo/ansprechpartner_test.go
@@ -88,7 +88,7 @@ func Test_Successful_Ansprechpartner_Validation(t *testing.T) {
 	validAnsprechpartners := []bo.BusinessObject{
 		validAp,
 	}
-	VerifySuccessValidations(t, validate, validAnsprechpartners)
+	VerifySuccessfulValidations(t, validate, validAnsprechpartners)
 }
 
 func Test_Empty_Ansprechpartner_Is_Creatable_Using_BoTyp(t *testing.T) {

--- a/bo/ansprechpartner_test.go
+++ b/bo/ansprechpartner_test.go
@@ -99,6 +99,6 @@ func Test_Empty_Ansprechpartner_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Ansprechpartner_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.ANSPRECHPARTNER))
+func Test_Serialized_Empty_Ansprechpartner_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.ANSPRECHPARTNER))
 }

--- a/bo/avis_test.go
+++ b/bo/avis_test.go
@@ -355,6 +355,6 @@ func Test_Empty_Avis_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Avis_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.AVIS))
+func Test_Serialized_Empty_Avis_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.AVIS))
 }

--- a/bo/avis_test.go
+++ b/bo/avis_test.go
@@ -344,7 +344,7 @@ func Test_Successful_AvisValidation(t *testing.T) {
 			ZuZahlen:       avisPositive.GesamtBrutto,
 		},
 	}
-	VerifySuccessValidations(t, validate, validAvises)
+	VerifySuccessfulValidations(t, validate, validAvises)
 }
 
 func Test_Empty_Avis_Is_Creatable_Using_BoTyp(t *testing.T) {

--- a/bo/avis_test.go
+++ b/bo/avis_test.go
@@ -2,6 +2,7 @@ package bo_test
 
 import (
 	"reflect"
+	"testing"
 	"time"
 
 	"github.com/corbym/gocrest/is"
@@ -17,7 +18,7 @@ import (
 )
 
 // TestFailedAvisValidation verifies that the validators of Avis work
-func (s *Suite) Test_Failed_AvisValidation() {
+func Test_Failed_AvisValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(bo.AvisStructLevelValidation, bo.Avis{})
 	ungleichVertragsbeginn := abweichungsgrund.ABRECHNUNGSBEGINN_UNGLEICH_VERTRAGSBEGINN
@@ -280,11 +281,11 @@ func (s *Suite) Test_Failed_AvisValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidAvisMap)
+	VerifyFailedValidations(t, validate, invalidAvisMap)
 }
 
 // TestSuccessfulMesslokationValidation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_AvisValidation() {
+func Test_Successful_AvisValidation(t *testing.T) {
 	validate := validator.New()
 	ungleichVertragsbeginn := abweichungsgrund.ABRECHNUNGSBEGINN_UNGLEICH_VERTRAGSBEGINN
 	bemerkung := "C"
@@ -343,15 +344,15 @@ func (s *Suite) Test_Successful_AvisValidation() {
 			ZuZahlen:       avisPositive.GesamtBrutto,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAvises)
+	VerifySuccessValidations(t, validate, validAvises)
 }
 
-func (s *Suite) Test_Empty_Avis_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Avis_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.AVIS)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Avis{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.AVIS))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Avis{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.AVIS))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Avis_Contains_No_Enum_Defaults() {

--- a/bo/bilanzierung_test.go
+++ b/bo/bilanzierung_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/corbym/gocrest/is"
@@ -71,38 +72,38 @@ var validBilanzierung = bo.Bilanzierung{
 }
 
 // Test_Bilanzierung_Deserialization deserializes an Bilanzierung json
-func (s *Suite) Test_Bilanzierung_Deserialization() {
+func Test_Bilanzierung_Deserialization(t *testing.T) {
 	serializedBilanzierung, err := json.Marshal(validBilanzierung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedBilanzierung, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedBilanzierung, is.Not(is.NilArray[byte]()))
 	jsonString := string(serializedBilanzierung)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "SLP_SEP"), is.True()) // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "SLP_SEP"), is.True()) // stringified enum
 	var deserializedBilanzierung bo.Bilanzierung
 	err = json.Unmarshal(serializedBilanzierung, &deserializedBilanzierung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedBilanzierung, is.EqualTo(validBilanzierung))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedBilanzierung, is.EqualTo(validBilanzierung))
 }
 
-func (s *Suite) Test_Bilanzierung_Deserializes_Unknown_Fields() {
+func Test_Bilanzierung_Deserializes_Unknown_Fields(t *testing.T) {
 	jsonString := `{"jahresverbrauchsprognose":{"wert":2345},"kundenwert":{"wert":38},"bilanzierungsbeginn":"2021-12-31T23:00:00+00:00","bilanzkreis":"THE0BFL002410004","prognosegrundlage":"PROFILE","detailsPrognosegrundlage":["SLP_SEP"],"boTyp":"BILANZIERUNG","versionStruktur":"1","Klassentyp":"Z12","Verfahren":"SYNTHETISCH","Profil":"D13","Lastprofil_Codeliste":"293","Temperaturmessstelle_Klassentyp":"Z99","Temperaturmessstelle_ID":"107290","Temperaturmessstelle_Anbieter":"ZT3","Temperaturmessstelle_Codeliste":"293"}`
 	var deserializedBilanzierung bo.Bilanzierung
 	err := json.Unmarshal([]byte(jsonString), &deserializedBilanzierung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), *deserializedBilanzierung.Bilanzkreis, is.EqualTo("THE0BFL002410004"))                  // a "normal" property/field of Bilanzierung
-	then.AssertThat(s.T(), deserializedBilanzierung.ExtensionData["Lastprofil_Codeliste"], is.EqualTo[any]("293")) // an extension data key
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, *deserializedBilanzierung.Bilanzkreis, is.EqualTo("THE0BFL002410004"))                  // a "normal" property/field of Bilanzierung
+	then.AssertThat(t, deserializedBilanzierung.ExtensionData["Lastprofil_Codeliste"], is.EqualTo[any]("293")) // an extension data key
 	jsonStringBytes, serializationErr := json.Marshal(deserializedBilanzierung)
-	then.AssertThat(s.T(), serializationErr, is.Nil())
+	then.AssertThat(t, serializationErr, is.Nil())
 	jsonString = string(jsonStringBytes)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "\"Lastprofil_Codeliste\""), is.True())
+	then.AssertThat(t, strings.Contains(jsonString, "\"Lastprofil_Codeliste\""), is.True())
 }
 
 // Test_Failed_Bilanzierung_Validation verifies that the validators of a Bilanzierung BO work
-func (s *Suite) Test_Failed_Bilanzierung_Validation() {
+func Test_Failed_Bilanzierung_Validation(t *testing.T) {
 	validate := validator.New()
 	err := validate.RegisterValidation("eic", bo.EICFieldLevelValidation)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	err = validate.RegisterValidation("maloid", bo.MaloIdFieldLevelValidation)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	invalidBilanzierungs := map[string][]interface{}{
 		"required": {
 			bo.Bilanzierung{},
@@ -136,29 +137,29 @@ func (s *Suite) Test_Failed_Bilanzierung_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidBilanzierungs)
+	VerifyFailedValidations(t, validate, invalidBilanzierungs)
 }
 
 // Test_Successful_Bilanzierung_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Bilanzierung_Validation() {
+func Test_Successful_Bilanzierung_Validation(t *testing.T) {
 	validate := validator.New()
 	err := validate.RegisterValidation("eic", bo.EICFieldLevelValidation)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	err = validate.RegisterValidation("maloid", bo.MaloIdFieldLevelValidation)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	validMarktteilnehmers := []bo.BusinessObject{
 		validBilanzierung,
 		bilanzierungWithNilAbwicklungsmodell(validBilanzierung),
 	}
-	VerfiySuccessfulValidations(s, validate, validMarktteilnehmers)
+	VerifySuccessfulValidations(t, validate, validMarktteilnehmers)
 }
 
-func (s *Suite) Test_Empty_Bilanzierung_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Bilanzierung_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.BILANZIERUNG)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Bilanzierung{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.BILANZIERUNG))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Bilanzierung{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.BILANZIERUNG))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Bilanzierung_Contains_No_Enum_Defaults() {

--- a/bo/bilanzierung_test.go
+++ b/bo/bilanzierung_test.go
@@ -162,8 +162,8 @@ func Test_Empty_Bilanzierung_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Bilanzierung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.BILANZIERUNG))
+func Test_Serialized_Empty_Bilanzierung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.BILANZIERUNG))
 }
 
 // bilanzierungWithNilAbwicklungsmodell returns a copy of bilanzierung with Abwicklungsmodell set to nil.

--- a/bo/businessobject_slice_test.go
+++ b/bo/businessobject_slice_test.go
@@ -2,6 +2,9 @@ package bo_test
 
 import (
 	"encoding/json"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/bo"
@@ -18,7 +21,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/hochfrequenz/go-bo4e/market_communication"
 	"github.com/shopspring/decimal"
-	"time"
 )
 
 var SliceWithThreeValidBos = bo.BusinessObjectSlice{
@@ -62,27 +64,27 @@ var SliceWithThreeValidBos = bo.BusinessObjectSlice{
 	},
 }
 
-func (s *Suite) Test_Successful_Slice_Deserialization() {
+func Test_Successful_Slice_Deserialization(t *testing.T) {
 	boList := SliceWithThreeValidBos
 	jsonBytes, err := json.Marshal(boList)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	var unmarshalledSlice bo.BusinessObjectSlice
 	err = json.Unmarshal(jsonBytes, &unmarshalledSlice)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), len(unmarshalledSlice), is.EqualTo(3))
-	then.AssertThat(s.T(), unmarshalledSlice, is.EqualTo(boList))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, len(unmarshalledSlice), is.EqualTo(3))
+	then.AssertThat(t, unmarshalledSlice, is.EqualTo(boList))
 }
 
-func (s *Suite) Test_Slice_Deserialization_Fails_For_Invalid_BoTyps() {
+func Test_Slice_Deserialization_Fails_For_Invalid_BoTyps(t *testing.T) {
 	jsonWithInvalidBoTyp := "[{\"boTyp\":\"foo\"}]" // foo is not a valid boTyp => deserialization should fail
 	var deserializedBoneyComb market_communication.BOneyComb
 	err := json.Unmarshal([]byte(jsonWithInvalidBoTyp), &deserializedBoneyComb)
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
-func (s *Suite) Test_Slice_Deserialization_Fails_For_Unimplemented_BoTyps() {
+func Test_Slice_Deserialization_Fails_For_Unimplemented_BoTyps(t *testing.T) {
 	jsonWithUnimplementedBoTyp := "[{\"boTyp\":\"PREISBLATTUMLAGEN\"}]" // PREISBLATTUMLAGEN is not (yet) an implemented boTyp => deserialization should fail
 	var deserializedBoneyComb market_communication.BOneyComb
 	err := json.Unmarshal([]byte(jsonWithUnimplementedBoTyp), &deserializedBoneyComb)
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }

--- a/bo/energiemenge_test.go
+++ b/bo/energiemenge_test.go
@@ -2,6 +2,11 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -12,13 +17,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"strings"
-	"time"
 )
 
 // TestFailedEnergiemengeValidation verifies that the validators of Energiemenge work
-func (s *Suite) Test_Failed_EnergiemengeValidation() {
+func Test_Failed_EnergiemengeValidation(t *testing.T) {
 	var verbrauch = com.Verbrauch{
 		Startdatum:               time.Now(),
 		Enddatum:                 time.Now().Add(time.Minute * 15),
@@ -66,11 +68,11 @@ func (s *Suite) Test_Failed_EnergiemengeValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidEnergiemengeMap)
+	VerifyFailedValidations(t, validate, invalidEnergiemengeMap)
 }
 
 // TestSuccessfulMesslokationValidation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_EnergiemengeValidation() {
+func Test_Successful_EnergiemengeValidation(t *testing.T) {
 	validate := validator.New()
 	var verbrauch = com.Verbrauch{
 		Startdatum:               time.Now(),
@@ -92,21 +94,21 @@ func (s *Suite) Test_Successful_EnergiemengeValidation() {
 			Verbrauch:    []com.Verbrauch{verbrauch},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validEnergiemengen)
+	VerifySuccessfulValidations(t, validate, validEnergiemengen)
 }
 
-func (s *Suite) Test_Empty_Energiemenge_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Energiemenge_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.ENERGIEMENGE)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Energiemenge{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.ENERGIEMENGE))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Energiemenge{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.ENERGIEMENGE))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Empty_Something_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Something_Is_Creatable_Using_BoTyp(t *testing.T) {
 	// remove this test as soon as the TARIFPREISBLATT is implemented. just to cover the nil case
 	object := bo.NewBusinessObject(botyp.TARIFPREISBLATT)
-	then.AssertThat(s.T(), object, is.EqualTo[bo.BusinessObject](nil))
+	then.AssertThat(t, object, is.EqualTo[bo.BusinessObject](nil))
 }
 
 func (s *Suite) Test_Serialized_Empty_Energiemenge_Contains_No_Enum_Defaults() {

--- a/bo/energiemenge_test.go
+++ b/bo/energiemenge_test.go
@@ -1,9 +1,7 @@
 package bo_test
 
 import (
-	"encoding/json"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
@@ -111,13 +109,6 @@ func Test_Empty_Something_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object, is.EqualTo[bo.BusinessObject](nil))
 }
 
-func (s *Suite) Test_Serialized_Empty_Energiemenge_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.ENERGIEMENGE))
-}
-
-func (s *Suite) assert_Does_Not_Serialize_Default_Enums(bo bo.BusinessObject) {
-	jsonBytes, err := json.Marshal(bo)
-	then.AssertThat(s.T(), err, is.Nil())
-	jsonString := string(jsonBytes)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "(0)"), is.False())
+func Test_Serialized_Empty_Energiemenge_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.ENERGIEMENGE))
 }

--- a/bo/geschaeftspartner_test.go
+++ b/bo/geschaeftspartner_test.go
@@ -188,6 +188,6 @@ func Test_Empty_Geschaeftspartner_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Geschaeftspartner_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.GESCHAEFTSPARTNER))
+func Test_Serialized_Empty_Geschaeftspartner_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.GESCHAEFTSPARTNER))
 }

--- a/bo/geschaeftspartner_test.go
+++ b/bo/geschaeftspartner_test.go
@@ -2,6 +2,10 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -13,12 +17,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/kontaktart"
 	"github.com/hochfrequenz/go-bo4e/enum/landescode"
 	"github.com/hochfrequenz/go-bo4e/internal"
-	"reflect"
-	"strings"
 )
 
 // Test_Geschaeftspartner_Deserialization deserializes an Geschaeftspartner json
-func (s *Suite) Test_Geschaeftspartner_Deserialization() {
+func Test_Geschaeftspartner_Deserialization(t *testing.T) {
 	var gp = bo.Geschaeftspartner{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
 			BoTyp:             botyp.GESCHAEFTSPARTNER,
@@ -53,17 +55,17 @@ func (s *Suite) Test_Geschaeftspartner_Deserialization() {
 	}
 	serializedGp, err := json.Marshal(gp)
 	jsonString := string(serializedGp)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "DIVERS"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedGp, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "DIVERS"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedGp, is.Not(is.NilArray[byte]()))
 	var deserializedGp bo.Geschaeftspartner
 	err = json.Unmarshal(serializedGp, &deserializedGp)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedGp, is.EqualTo(gp))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedGp, is.EqualTo(gp))
 }
 
 // TestFailedGeschaeftspartnerValidation verifies that the validators of a Geschaeftspartner work
-func (s *Suite) Test_Failed_GeschaeftspartnerValidation() {
+func Test_Failed_GeschaeftspartnerValidation(t *testing.T) {
 	var adresse = com.Adresse{
 		Postleitzahl: "82031",
 		Ort:          "Grünwald",
@@ -145,7 +147,7 @@ func (s *Suite) Test_Failed_GeschaeftspartnerValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVertrags)
+	VerifyFailedValidations(t, validate, invalidVertrags)
 }
 
 var validGp = bo.Geschaeftspartner{
@@ -169,21 +171,21 @@ var validGp = bo.Geschaeftspartner{
 }
 
 // Test_Successful_Geschaeftspartner_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Geschaeftspartner_Validation() {
+func Test_Successful_Geschaeftspartner_Validation(t *testing.T) {
 
 	validate := validator.New()
 	validGeschaeftspartners := []bo.BusinessObject{
 		validGp,
 	}
-	VerfiySuccessfulValidations(s, validate, validGeschaeftspartners)
+	VerifySuccessfulValidations(t, validate, validGeschaeftspartners)
 }
 
-func (s *Suite) Test_Empty_Geschaeftspartner_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Geschaeftspartner_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.GESCHAEFTSPARTNER)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Geschaeftspartner{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.GESCHAEFTSPARTNER))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Geschaeftspartner{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.GESCHAEFTSPARTNER))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Geschaeftspartner_Contains_No_Enum_Defaults() {

--- a/bo/handelsunstimmigkeit_test.go
+++ b/bo/handelsunstimmigkeit_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"testing"
 
 	"github.com/go-playground/validator/v10"
 
@@ -19,7 +20,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func (s *Suite) Test_Handelsunstimmigkeit_Deserialization() {
+func Test_Handelsunstimmigkeit_Deserialization(t *testing.T) {
 	h := bo.Handelsunstimmigkeit{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
 			BoTyp:           botyp.HANDELSUNSTIMMIGKEIT,
@@ -38,19 +39,19 @@ func (s *Suite) Test_Handelsunstimmigkeit_Deserialization() {
 	}
 
 	serialized, err := json.Marshal(h)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serialized, is.Not(is.NilArray[byte]()))
-	then.AssertThat(s.T(), strings.Contains(string(serialized), "NN_MSCONS_UEBERSENDET"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serialized), "HANDELSRECHNUNG"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serialized), "456"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serialized), "123"), is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serialized, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(string(serialized), "NN_MSCONS_UEBERSENDET"), is.True())
+	then.AssertThat(t, strings.Contains(string(serialized), "HANDELSRECHNUNG"), is.True())
+	then.AssertThat(t, strings.Contains(string(serialized), "456"), is.True())
+	then.AssertThat(t, strings.Contains(string(serialized), "123"), is.True())
 	var deserialized bo.Handelsunstimmigkeit
 	err = json.Unmarshal(serialized, &deserialized)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserialized, is.EqualTo(h))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserialized, is.EqualTo(h))
 }
 
-func (s *Suite) Test_Failed_Handelsunstimmigkeit_Validation() {
+func Test_Failed_Handelsunstimmigkeit_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidMap := map[string][]interface{}{
 		"required": {
@@ -66,10 +67,10 @@ func (s *Suite) Test_Failed_Handelsunstimmigkeit_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidMap)
+	VerifyFailedValidations(t, validate, invalidMap)
 }
 
-func (s *Suite) Test_Successful_Handelsunstimmigkeit_Validation() {
+func Test_Successful_Handelsunstimmigkeit_Validation(t *testing.T) {
 	validate := validator.New()
 	validBO := []bo.BusinessObject{
 		bo.Handelsunstimmigkeit{
@@ -86,15 +87,15 @@ func (s *Suite) Test_Successful_Handelsunstimmigkeit_Validation() {
 			},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validBO)
+	VerifySuccessfulValidations(t, validate, validBO)
 }
 
-func (s *Suite) Test_Empty_Handelsunstimmigkeit_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Handelsunstimmigkeit_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.HANDELSUNSTIMMIGKEIT)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Handelsunstimmigkeit{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.HANDELSUNSTIMMIGKEIT))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Handelsunstimmigkeit{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.HANDELSUNSTIMMIGKEIT))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Handelsunstimmigkeit_Contains_No_Enum_Defaults() {

--- a/bo/handelsunstimmigkeit_test.go
+++ b/bo/handelsunstimmigkeit_test.go
@@ -98,6 +98,6 @@ func Test_Empty_Handelsunstimmigkeit_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Handelsunstimmigkeit_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.HANDELSUNSTIMMIGKEIT))
+func Test_Serialized_Empty_Handelsunstimmigkeit_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.HANDELSUNSTIMMIGKEIT))
 }

--- a/bo/lastgang_test.go
+++ b/bo/lastgang_test.go
@@ -119,6 +119,6 @@ func Test_Empty_Lastgang_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Lastgang_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.LASTGANG))
+func Test_Serialized_Empty_Lastgang_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.LASTGANG))
 }

--- a/bo/lastgang_test.go
+++ b/bo/lastgang_test.go
@@ -1,6 +1,10 @@
 package bo_test
 
 import (
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -14,12 +18,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"time"
 )
 
 // TestFailedLastgangValidation verifies that the validators of a Lastgang work
-func (s *Suite) Test_Failed_LastgangValidation() {
+func Test_Failed_LastgangValidation(t *testing.T) {
 	var zeitreihenwert = com.Zeitreihenwert{
 		Zeitreihenwertkompakt: com.Zeitreihenwertkompakt{
 			Wert:         decimal.NewFromFloat(17.43),
@@ -80,11 +82,11 @@ func (s *Suite) Test_Failed_LastgangValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidLastgangMap)
+	VerifyFailedValidations(t, validate, invalidLastgangMap)
 }
 
 // Test_Successful_Lastgang_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Lastgang_Validation() {
+func Test_Successful_Lastgang_Validation(t *testing.T) {
 	validate := validator.New()
 	var verbrauch = com.Verbrauch{
 		Startdatum:               time.Now(),
@@ -106,15 +108,15 @@ func (s *Suite) Test_Successful_Lastgang_Validation() {
 			Verbrauch:    []com.Verbrauch{verbrauch},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validLastgang)
+	VerifySuccessfulValidations(t, validate, validLastgang)
 }
 
-func (s *Suite) Test_Empty_Lastgang_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Lastgang_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.LASTGANG)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Lastgang{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.LASTGANG))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Lastgang{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.LASTGANG))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Lastgang_Contains_No_Enum_Defaults() {

--- a/bo/marktlokation_test.go
+++ b/bo/marktlokation_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"testing"
 
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
@@ -27,7 +28,7 @@ import (
 )
 
 // Test_Marktlokation_Deserialization tests serialization and deserialization of Marktlokation
-func (s *Suite) Test_Marktlokation_Deserialization() {
+func Test_Marktlokation_Deserialization(t *testing.T) {
 	f := false
 	gesperrt := sperrstatus.GESPERRT
 	var malo = bo.Marktlokation{
@@ -91,29 +92,29 @@ func (s *Suite) Test_Marktlokation_Deserialization() {
 		Sperrstatus: &gesperrt,
 	}
 	serializedMalo, err := json.Marshal(malo)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedMalo, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedMalo, is.Not(is.NilArray[byte]()))
 	stringSerializedMalo := string(serializedMalo)
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "STROM"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "AUSSP"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "RLM"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "KL"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "MSP"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "GRUNDVERSORGUNGSGEBIET"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "DE"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "ADDITION"), is.True())
-	then.AssertThat(s.T(), strings.Contains(stringSerializedMalo, "\"unterbrechbar\":false"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "STROM"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "AUSSP"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "RLM"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "KL"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "MSP"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "GRUNDVERSORGUNGSGEBIET"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "DE"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "ADDITION"), is.True())
+	then.AssertThat(t, strings.Contains(stringSerializedMalo, "\"unterbrechbar\":false"), is.True())
 	var deserializedMalo bo.Marktlokation
 	err = json.Unmarshal(serializedMalo, &deserializedMalo)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 
 	expectedJson, _ := json.Marshal(malo)
 	actualJson, _ := json.Marshal(deserializedMalo)
-	then.AssertThat(s.T(), expectedJson, is.EqualTo(actualJson))
+	then.AssertThat(t, expectedJson, is.EqualTo(actualJson))
 }
 
 //nolint:dupl // This can only be simplified if we use generics. anything else seems overly complicated but maybe it's just me
-func (s *Suite) Test_Marktlokation_DeSerialization_With_Unkonwn_Fields() {
+func Test_Marktlokation_DeSerialization_With_Unkonwn_Fields(t *testing.T) {
 	// this is a json that contains fields/keys that are not part of the official bo4e standard.
 	// our expectation is that they are deserialized into the "ExtensionData" field.
 	// They should also be serialized from there / not be lost during a marshalling/unmarshalling round trip
@@ -169,26 +170,26 @@ func (s *Suite) Test_Marktlokation_DeSerialization_With_Unkonwn_Fields() {
 
 	// unmarshalling tests
 	err := json.Unmarshal([]byte(maloJsonWithUnknownFields), &malo)
-	then.AssertThat(s.T(), err, is.Nil())
-	//then.AssertThat(s.T(), malo.ExtensionData, is.Not(is.Nil()))             // ExtensionData is not nullable
-	then.AssertThat(s.T(), malo.Zaehlwerke, is.Not(is.NilArray[com.Zaehlwerk]()))        // marktloktion->zaehlwerke is NOT part of the bo4e standard ==> present in extension data
-	then.AssertThat(s.T(), malo.ExtensionData["marktlokationsId"], is.EqualTo[any](nil)) // marktlokation->marklokationsId is part of the bo4e standard ==> not present in extension data
-	then.AssertThat(s.T(), malo.MarktlokationsId, is.EqualTo("10024073272"))             // but where it should be
+	then.AssertThat(t, err, is.Nil())
+	//then.AssertThat(t, malo.ExtensionData, is.Not(is.Nil()))             // ExtensionData is not nullable
+	then.AssertThat(t, malo.Zaehlwerke, is.Not(is.NilArray[com.Zaehlwerk]()))        // marktloktion->zaehlwerke is NOT part of the bo4e standard ==> present in extension data
+	then.AssertThat(t, malo.ExtensionData["marktlokationsId"], is.EqualTo[any](nil)) // marktlokation->marklokationsId is part of the bo4e standard ==> not present in extension data
+	then.AssertThat(t, malo.MarktlokationsId, is.EqualTo("10024073272"))             // but where it should be
 	// the other fields should be fine, too, without explicit tests; Add them if you feel like it doesn't work
 
 	// marshaling tests
 	serializedMaloBytes, errSerializing := json.Marshal(malo)
-	then.AssertThat(s.T(), errSerializing, is.Nil())
+	then.AssertThat(t, errSerializing, is.Nil())
 	serializedMaLo := string(serializedMaloBytes)
-	then.AssertThat(s.T(), strings.Contains(serializedMaLo, "zaehlwerke"), is.True())       // unmapped fields should be part of the serialized malo
-	then.AssertThat(s.T(), strings.Contains(serializedMaLo, "marktlokationsId"), is.True()) // mapped fields should be part of the serialized malo
+	then.AssertThat(t, strings.Contains(serializedMaLo, "zaehlwerke"), is.True())       // unmapped fields should be part of the serialized malo
+	then.AssertThat(t, strings.Contains(serializedMaLo, "marktlokationsId"), is.True()) // mapped fields should be part of the serialized malo
 }
 
 // TestFailedMarktlokationValidation verifies that the validators of Marktlokation work
-func (s *Suite) Test_Failed_MarktlokationValidation() {
+func Test_Failed_MarktlokationValidation(t *testing.T) {
 	validate := validator.New()
 	registerError := validate.RegisterValidation("maloid", bo.MaloIdFieldLevelValidation)
-	then.AssertThat(s.T(), registerError, is.Nil())
+	then.AssertThat(t, registerError, is.Nil())
 	validate.RegisterStructValidation(bo.XorStructLevelValidation, bo.Marktlokation{})
 
 	invalidMarktlokationMap := map[string][]interface{}{
@@ -248,14 +249,14 @@ func (s *Suite) Test_Failed_MarktlokationValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidMarktlokationMap)
+	VerifyFailedValidations(t, validate, invalidMarktlokationMap)
 }
 
 // Test_Successful_Marktlokation_Validation verifies that a valid Marktlokation is validated without errors
-func (s *Suite) Test_Successful_Marktlokation_Validation() {
+func Test_Successful_Marktlokation_Validation(t *testing.T) {
 	validate := validator.New()
 	registerError := validate.RegisterValidation("maloid", bo.MaloIdFieldLevelValidation)
-	then.AssertThat(s.T(), registerError, is.Nil())
+	then.AssertThat(t, registerError, is.Nil())
 	validate.RegisterStructValidation(bo.XorStructLevelValidation, bo.Marktlokation{})
 	validMalos := []bo.BusinessObject{
 		// Minimal attributes
@@ -297,20 +298,20 @@ func (s *Suite) Test_Successful_Marktlokation_Validation() {
 			},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validMalos)
+	VerifySuccessfulValidations(t, validate, validMalos)
 }
 
-func (s *Suite) Test_Get_MaloId_Checksum() {
+func Test_Get_MaloId_Checksum(t *testing.T) {
 	actual := bo.GetMaLoIdCheckSum("5123869678")
-	then.AssertThat(s.T(), actual, is.EqualTo(1))
+	then.AssertThat(t, actual, is.EqualTo(1))
 }
 
-func (s *Suite) Test_Empty_Marktlokation_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Marktlokation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.MARKTLOKATION)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Marktlokation{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.MARKTLOKATION))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Marktlokation{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.MARKTLOKATION))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Marktlokation_Contains_No_Enum_Defaults() {

--- a/bo/marktlokation_test.go
+++ b/bo/marktlokation_test.go
@@ -314,6 +314,6 @@ func Test_Empty_Marktlokation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Marktlokation_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.MARKTLOKATION))
+func Test_Serialized_Empty_Marktlokation_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.MARKTLOKATION))
 }

--- a/bo/marktteilnehmer_test.go
+++ b/bo/marktteilnehmer_test.go
@@ -147,6 +147,6 @@ func Test_Empty_Markteilnehmer_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Marktteilnehmer_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.MARKTTEILNEHMER))
+func Test_Serialized_Empty_Marktteilnehmer_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.MARKTTEILNEHMER))
 }

--- a/bo/marktteilnehmer_test.go
+++ b/bo/marktteilnehmer_test.go
@@ -2,9 +2,11 @@ package bo_test
 
 import (
 	"encoding/json"
-	"github.com/hochfrequenz/go-bo4e/internal"
 	"reflect"
 	"strings"
+	"testing"
+
+	"github.com/hochfrequenz/go-bo4e/internal"
 
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
@@ -22,7 +24,7 @@ import (
 )
 
 // Test_Marktteilnehmer_Deserialization deserializes an Marktteilnehmer json
-func (s *Suite) Test_Marktteilnehmer_Deserialization() {
+func Test_Marktteilnehmer_Deserialization(t *testing.T) {
 	var mt = bo.Marktteilnehmer{
 		Marktrolle:       marktrolle.LF,
 		Makoadresse:      "edifact@my-favourite-marketpartner.de",
@@ -74,18 +76,18 @@ func (s *Suite) Test_Marktteilnehmer_Deserialization() {
 	}
 	serializedMarktteilnehmer, err := json.Marshal(mt)
 	jsonString := string(serializedMarktteilnehmer)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "DVGW"), is.True()) // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "LF"), is.True())   // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedMarktteilnehmer, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "DVGW"), is.True()) // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "LF"), is.True())   // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedMarktteilnehmer, is.Not(is.NilArray[byte]()))
 	var deserializedMarktteilnehmer bo.Marktteilnehmer
 	err = json.Unmarshal(serializedMarktteilnehmer, &deserializedMarktteilnehmer)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedMarktteilnehmer, is.EqualTo(mt))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedMarktteilnehmer, is.EqualTo(mt))
 }
 
 // Test_Failed_Marktteilnehmer_Validation verifies that the validators of a Marktteilnehmer work
-func (s *Suite) Test_Failed_Marktteilnehmer_Validation() {
+func Test_Failed_Marktteilnehmer_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidMarktteilnehmer := map[string][]interface{}{
 		"required": {
@@ -101,11 +103,11 @@ func (s *Suite) Test_Failed_Marktteilnehmer_Validation() {
 			bo.Marktteilnehmer{Rollencodenummer: "asd"},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidMarktteilnehmer)
+	VerifyFailedValidations(t, validate, invalidMarktteilnehmer)
 }
 
 // Test_Successful_Marktteilnehmer_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Marktteilnehmer_Validation() {
+func Test_Successful_Marktteilnehmer_Validation(t *testing.T) {
 	validate := validator.New()
 	validMarktteilnehmers := []bo.BusinessObject{
 		bo.Marktteilnehmer{
@@ -134,15 +136,15 @@ func (s *Suite) Test_Successful_Marktteilnehmer_Validation() {
 			},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validMarktteilnehmers)
+	VerifySuccessfulValidations(t, validate, validMarktteilnehmers)
 }
 
-func (s *Suite) Test_Empty_Markteilnehmer_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Markteilnehmer_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.MARKTTEILNEHMER)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Marktteilnehmer{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.MARKTTEILNEHMER))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Marktteilnehmer{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.MARKTTEILNEHMER))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Marktteilnehmer_Contains_No_Enum_Defaults() {

--- a/bo/messlokation_test.go
+++ b/bo/messlokation_test.go
@@ -232,6 +232,6 @@ func Test_Empty_Messlokation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Messlokation_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.MESSLOKATION))
+func Test_Serialized_Empty_Messlokation_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.MESSLOKATION))
 }

--- a/bo/netzlokation_test.go
+++ b/bo/netzlokation_test.go
@@ -1,17 +1,19 @@
 package bo_test
 
 import (
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/bo"
 )
 
-func (s *Suite) Test_Get_NeloId_Checksum() {
+func Test_Get_NeloId_Checksum(t *testing.T) {
 	actual := bo.GetNeLoIdCheckSum("E113735592")
-	then.AssertThat(s.T(), actual, is.EqualTo(1))
+	then.AssertThat(t, actual, is.EqualTo(1))
 }
 
-func (s *Suite) Test_Get_NeloId_Doesnt_Panic() {
+func Test_Get_NeloId_Doesnt_Panic(t *testing.T) {
 	actual := bo.GetNeLoIdCheckSum("E5345G7F6F")
-	then.AssertThat(s.T(), actual, is.EqualTo(0))
+	then.AssertThat(t, actual, is.EqualTo(0))
 }

--- a/bo/netznutzungsrechnung_test.go
+++ b/bo/netznutzungsrechnung_test.go
@@ -2,6 +2,9 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -10,11 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/nnrechnungsart"
 	"github.com/hochfrequenz/go-bo4e/enum/nnrechnungstyp"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
-	"reflect"
 )
 
 // Test_Netznutzungsrechnung_Deserialization deserializes an Netznutzungsrechnung json
-func (s *Suite) Test_Netznutzungsrechnung_Deserialization() {
+func Test_Netznutzungsrechnung_Deserialization(t *testing.T) {
 	var nnrechnung = bo.Netznutzungsrechnung{
 		Rechnung:             serializableRechnung,
 		Sparte:               sparte.GAS,
@@ -27,16 +29,16 @@ func (s *Suite) Test_Netznutzungsrechnung_Deserialization() {
 		LokationsId:          "DE0123456789012345678901234567890",
 	}
 	serializedNnrechnung, err := json.Marshal(nnrechnung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedNnrechnung, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedNnrechnung, is.Not(is.NilArray[byte]()))
 	var deserializedRechnung bo.Netznutzungsrechnung
 	err = json.Unmarshal(serializedNnrechnung, &deserializedRechnung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedRechnung, is.EqualTo(nnrechnung))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedRechnung, is.EqualTo(nnrechnung))
 }
 
 // Test_Failed_Netznutzungsrechnung_Validation verifies that the validators of a Netznutzungsrechnung work
-func (s *Suite) Test_Failed_Netznutzungsrechnung_Validation() {
+func Test_Failed_Netznutzungsrechnung_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidNnrs := map[string][]interface{}{
 		"required": {
@@ -60,11 +62,11 @@ func (s *Suite) Test_Failed_Netznutzungsrechnung_Validation() {
 			bo.Netznutzungsrechnung{Empfaengercodenummer: "asd"},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidNnrs)
+	VerifyFailedValidations(t, validate, invalidNnrs)
 }
 
 // Test_Successful_Netznutzungsrechnung_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Netznutzungsrechnung_Validation() {
+func Test_Successful_Netznutzungsrechnung_Validation(t *testing.T) {
 	validate := validator.New()
 	validNnrs := []bo.BusinessObject{
 		bo.Netznutzungsrechnung{
@@ -79,15 +81,15 @@ func (s *Suite) Test_Successful_Netznutzungsrechnung_Validation() {
 			LokationsId:          "DE0123456789012345678901234567890",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validNnrs)
+	VerifySuccessfulValidations(t, validate, validNnrs)
 }
 
-func (s *Suite) Test_Empty_NNR_Is_Creatable_Using_BoTyp() {
+func Test_Empty_NNR_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.NETZNUTZUNGSRECHNUNG)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Netznutzungsrechnung{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.NETZNUTZUNGSRECHNUNG))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Netznutzungsrechnung{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.NETZNUTZUNGSRECHNUNG))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Netznutzungsrechnung_Contains_No_Enum_Defaults() {

--- a/bo/netznutzungsrechnung_test.go
+++ b/bo/netznutzungsrechnung_test.go
@@ -92,6 +92,6 @@ func Test_Empty_NNR_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Netznutzungsrechnung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.NETZNUTZUNGSRECHNUNG))
+func Test_Serialized_Empty_Netznutzungsrechnung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.NETZNUTZUNGSRECHNUNG))
 }

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -177,6 +177,6 @@ func Test_Empty_Preisblatt_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Preisblatt_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.PREISBLATT))
+func Test_Serialized_Empty_Preisblatt_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.PREISBLATT))
 }

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -2,6 +2,11 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -18,13 +23,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungseinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"strings"
-	"time"
 )
 
 // Test_Preisblatt_Deserialization tests serialization and deserialization of Preisblatt
-func (s *Suite) Test_Preisblatt_Deserialization() {
+func Test_Preisblatt_Deserialization(t *testing.T) {
 	artikel := func(i bdewartikelnummer.BDEWArtikelnummer) *bdewartikelnummer.BDEWArtikelnummer { return &i }
 	var pricat = bo.Preisblatt{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
@@ -75,26 +77,26 @@ func (s *Suite) Test_Preisblatt_Deserialization() {
 		},
 	}
 	serializedPricat, err := json.Marshal(pricat)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedPricat, is.Not(is.NilArray[byte]()))
-	then.AssertThat(s.T(), strings.Contains(string(serializedPricat), "STROM"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serializedPricat), "MSB_INKL_MESSUNG"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serializedPricat), "EUR"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serializedPricat), "BDEW"), is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedPricat, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(string(serializedPricat), "STROM"), is.True())
+	then.AssertThat(t, strings.Contains(string(serializedPricat), "MSB_INKL_MESSUNG"), is.True())
+	then.AssertThat(t, strings.Contains(string(serializedPricat), "EUR"), is.True())
+	then.AssertThat(t, strings.Contains(string(serializedPricat), "BDEW"), is.True())
 	var deserializedPricat bo.Preisblatt
 	err = json.Unmarshal(serializedPricat, &deserializedPricat)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 
 	// The following lines prepare the deserialized pricat for the equality; The capacity of the slices is different, so the slice has to be created manually
 	// Also somehow the Preisstaffel raises the assertion, therefore it is replaced with the original
 	deserializedPricat.Preispositionen = []com.Preisposition{deserializedPricat.Preispositionen[0]}
 	//deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{deserializedPricat.Preispositionen[0].Preisstaffeln[0]}
 	deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{pricat.Preispositionen[0].Preisstaffeln[0]}
-	then.AssertThat(s.T(), deserializedPricat, is.EqualTo(pricat))
+	then.AssertThat(t, deserializedPricat, is.EqualTo(pricat))
 }
 
 // Test_Failed_PreisblattValidation verifies that the validators of Preisblatt work
-func (s *Suite) Test_Failed_PreisblattValidation() {
+func Test_Failed_PreisblattValidation(t *testing.T) {
 	validate := validator.New()
 	invalidPreisblattMap := map[string][]interface{}{
 		"required": {
@@ -116,11 +118,11 @@ func (s *Suite) Test_Failed_PreisblattValidation() {
 			bo.Preisblatt{},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidPreisblattMap)
+	VerifyFailedValidations(t, validate, invalidPreisblattMap)
 }
 
 // Test_Successful_Preisblatt_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Preisblatt_Validation() {
+func Test_Successful_Preisblatt_Validation(t *testing.T) {
 	ad := func(adresse com.Adresse) *com.Adresse { return &adresse }
 	validate := validator.New()
 	validPricat := []bo.BusinessObject{
@@ -164,15 +166,15 @@ func (s *Suite) Test_Successful_Preisblatt_Validation() {
 			Preispositionen: []com.Preisposition{},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validPricat)
+	VerifySuccessfulValidations(t, validate, validPricat)
 }
 
-func (s *Suite) Test_Empty_Preisblatt_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Preisblatt_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.PREISBLATT)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Preisblatt{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.PREISBLATT))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Preisblatt{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.PREISBLATT))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Preisblatt_Contains_No_Enum_Defaults() {

--- a/bo/rechnung_test.go
+++ b/bo/rechnung_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"reflect"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/hochfrequenz/go-bo4e/internal"
@@ -134,20 +135,20 @@ var serializableRechnung = bo.Rechnung{
 }
 
 // Test_Rechnung_Deserialization deserializes an Rechnung json
-func (s *Suite) Test_Rechnung_Deserialization() {
+func Test_Rechnung_Deserialization(t *testing.T) {
 	serializedRechnung, err := json.Marshal(serializableRechnung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedRechnung, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedRechnung, is.Not(is.NilArray[byte]()))
 	rechnungJsonString := string(serializedRechnung)
-	then.AssertThat(s.T(), strings.Contains(rechnungJsonString, "\"buchungsdatum\":\"2022-09-22T00:00:00Z\""), is.True())
+	then.AssertThat(t, strings.Contains(rechnungJsonString, "\"buchungsdatum\":\"2022-09-22T00:00:00Z\""), is.True())
 	var deserializedRechnung bo.Rechnung
 	err = json.Unmarshal(serializedRechnung, &deserializedRechnung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedRechnung, is.EqualTo(serializableRechnung))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedRechnung, is.EqualTo(serializableRechnung))
 }
 
 // TestFailedRechnungValidation verifies that the validators of a Rechnung work
-func (s *Suite) Test_Failed_RechnungValidation() {
+func Test_Failed_RechnungValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(bo.RechnungStructLevelValidation, bo.Rechnung{})
 	invalidRechnungs := map[string][]interface{}{
@@ -260,17 +261,17 @@ func (s *Suite) Test_Failed_RechnungValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidRechnungs)
+	VerifyFailedValidations(t, validate, invalidRechnungs)
 }
 
 // Test_Successful_Rechnung_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Rechnung_Validation() {
+func Test_Successful_Rechnung_Validation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(bo.RechnungStructLevelValidation, bo.Rechnung{})
 	validRechnung := []bo.BusinessObject{
 		completeValidRechnung,
 	}
-	VerfiySuccessfulValidations(s, validate, validRechnung)
+	VerifySuccessfulValidations(t, validate, validRechnung)
 }
 
 var completeValidRechnung = bo.Rechnung{
@@ -411,12 +412,12 @@ var completeValidRechnung = bo.Rechnung{
 	},
 }
 
-func (s *Suite) Test_Empty_Rechnung_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Rechnung_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.RECHNUNG)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Rechnung{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.RECHNUNG))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Rechnung{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.RECHNUNG))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Rechnung_Contains_No_Enum_Defaults() {

--- a/bo/rechnung_test.go
+++ b/bo/rechnung_test.go
@@ -420,6 +420,6 @@ func Test_Empty_Rechnung_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Rechnung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.RECHNUNG))
+func Test_Serialized_Empty_Rechnung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.RECHNUNG))
 }

--- a/bo/reklamation_test.go
+++ b/bo/reklamation_test.go
@@ -101,6 +101,6 @@ func Test_Empty_Reklamation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Reklamation_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.REKLAMATION))
+func Test_Serialized_Empty_Reklamation_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.REKLAMATION))
 }

--- a/bo/reklamation_test.go
+++ b/bo/reklamation_test.go
@@ -2,6 +2,8 @@ package bo_test
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -17,7 +19,7 @@ import (
 )
 
 // Test_Reklamation_Deserialization tests serialization and deserialization of Reklamation
-func (s *Suite) Test_Reklamation_Deserialization() {
+func Test_Reklamation_Deserialization(t *testing.T) {
 	obis := func(s string) *string { return &s }
 	var reklamation = bo.Reklamation{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
@@ -34,17 +36,17 @@ func (s *Suite) Test_Reklamation_Deserialization() {
 		Reklamationsgrund: reklamationsgrund.WERTE_FEHLEN,
 	}
 	serializedReklamation, err := json.Marshal(reklamation)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedReklamation, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedReklamation, is.Not(is.NilArray[byte]()))
 	var deserializedReklamation bo.Reklamation
 	err = json.Unmarshal(serializedReklamation, &deserializedReklamation)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 
-	then.AssertThat(s.T(), deserializedReklamation, is.EqualTo(reklamation))
+	then.AssertThat(t, deserializedReklamation, is.EqualTo(reklamation))
 }
 
 // Test_Failed_ReklamationValidation verifies that the validators of Reklamation work
-func (s *Suite) Test_Failed_ReklamationValidation() {
+func Test_Failed_ReklamationValidation(t *testing.T) {
 	validate := validator.New()
 	invalidReklamationMap := map[string][]interface{}{
 		"required": {
@@ -62,11 +64,11 @@ func (s *Suite) Test_Failed_ReklamationValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidReklamationMap)
+	VerifyFailedValidations(t, validate, invalidReklamationMap)
 }
 
 // Test_Successful_Reklamation_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Reklamation_Validation() {
+func Test_Successful_Reklamation_Validation(t *testing.T) {
 	obis := func(s string) *string { return &s }
 	validate := validator.New()
 	validPricat := []bo.BusinessObject{
@@ -88,15 +90,15 @@ func (s *Suite) Test_Successful_Reklamation_Validation() {
 			Reklamationsgrund: reklamationsgrund.WERTE_FEHLEN,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validPricat)
+	VerifySuccessfulValidations(t, validate, validPricat)
 }
 
-func (s *Suite) Test_Empty_Reklamation_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Reklamation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.REKLAMATION)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Reklamation{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.REKLAMATION))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Reklamation{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.REKLAMATION))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Reklamation_Contains_No_Enum_Defaults() {

--- a/bo/setup_test.go
+++ b/bo/setup_test.go
@@ -12,16 +12,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/bo"
 	"github.com/hochfrequenz/go-bo4e/enum/botyp"
 	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/suite"
 )
-
-type Suite struct {
-	suite.Suite
-}
-
-func TestInit(t *testing.T) {
-	suite.Run(t, new(Suite))
-}
 
 func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []bo.BusinessObject) {
 	// ToDo: use generics as soon as golangs allows to

--- a/bo/setup_test.go
+++ b/bo/setup_test.go
@@ -1,7 +1,9 @@
 package bo_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/corbym/gocrest/is"
@@ -72,4 +74,11 @@ func newDecimalFromString(s string) decimal.Decimal {
 		panic(fmt.Errorf("Error while converting '%s'", s))
 	}
 	return result
+}
+
+func assertDoesNotSerializeDefaultEnums(t *testing.T, bo bo.BusinessObject) {
+	jsonBytes, err := json.Marshal(bo)
+	then.AssertThat(t, err, is.Nil())
+	jsonString := string(jsonBytes)
+	then.AssertThat(t, strings.Contains(jsonString, "(0)"), is.False())
 }

--- a/bo/setup_test.go
+++ b/bo/setup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// VerifySuccessfulValidations asserts that the vali validator does not fail for all objects provided
 func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []bo.BusinessObject) {
 	// ToDo: use generics as soon as golangs allows to
 	for _, validObject := range validObjects {
@@ -23,6 +24,7 @@ func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validOb
 	}
 }
 
+// VerifyFailedValidations asserts that the vali validator fails with the expected tag for every object
 func VerifyFailedValidations(t *testing.T, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {
 	// ToDo: use generics as soon as golangs allows to
 	for validationTag, invalidObjects := range tagInvalidObjectsMap {

--- a/bo/setup_test.go
+++ b/bo/setup_test.go
@@ -23,11 +23,6 @@ func TestInit(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-// VerfiySuccessfulValidations asserts that the vali validator does not fail for all objects provided
-func VerfiySuccessfulValidations(s *Suite, vali *validator.Validate, validObjects []bo.BusinessObject) {
-	VerifySuccessfulValidations(s.T(), vali, validObjects)
-}
-
 func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []bo.BusinessObject) {
 	// ToDo: use generics as soon as golangs allows to
 	for _, validObject := range validObjects {
@@ -35,11 +30,6 @@ func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validOb
 		then.AssertThat(t, validObject.GetBoTyp(), is.Not(is.EqualTo[botyp.BOTyp](0))) // 0 would be iota/uninitialized botyp.BOTyp
 		then.AssertThat(t, err, is.Nil())
 	}
-}
-
-// VerfiyFailedValidations asserts that the vali validator fails with the expected tag for every object
-func VerfiyFailedValidations(s *Suite, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {
-	VerifyFailedValidations(s.T(), vali, tagInvalidObjectsMap)
 }
 
 func VerifyFailedValidations(t *testing.T, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {

--- a/bo/setup_test.go
+++ b/bo/setup_test.go
@@ -23,10 +23,10 @@ func TestInit(t *testing.T) {
 
 // VerfiySuccessfulValidations asserts that the vali validator does not fail for all objects provided
 func VerfiySuccessfulValidations(s *Suite, vali *validator.Validate, validObjects []bo.BusinessObject) {
-	VerifySuccessValidations(s.T(), vali, validObjects)
+	VerifySuccessfulValidations(s.T(), vali, validObjects)
 }
 
-func VerifySuccessValidations(t *testing.T, vali *validator.Validate, validObjects []bo.BusinessObject) {
+func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []bo.BusinessObject) {
 	// ToDo: use generics as soon as golangs allows to
 	for _, validObject := range validObjects {
 		err := vali.Struct(validObject)

--- a/bo/statusbericht_test.go
+++ b/bo/statusbericht_test.go
@@ -81,8 +81,8 @@ func Test_Empty_Statusbericht_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Statusbericht_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.STATUSBERICHT))
+func Test_Serialized_Empty_Statusbericht_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.STATUSBERICHT))
 }
 
 func stringAsPointer(s string) *string {

--- a/bo/statusbericht_test.go
+++ b/bo/statusbericht_test.go
@@ -2,9 +2,11 @@ package bo_test
 
 import (
 	"encoding/json"
-	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"reflect"
+	"testing"
 	"time"
+
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/fehlercode"
@@ -20,7 +22,7 @@ import (
 )
 
 // Test_Statusbericht_Deserialization deserializes an Statusbericht json
-func (s *Suite) Test_Statusbericht_Deserialization() {
+func Test_Statusbericht_Deserialization(t *testing.T) {
 	gegenstand := "Nachricht123"
 	var bericht = bo.Statusbericht{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
@@ -52,31 +54,31 @@ func (s *Suite) Test_Statusbericht_Deserialization() {
 	}
 
 	serializedBericht, err := json.Marshal(bericht)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedBericht, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedBericht, is.Not(is.NilArray[byte]()))
 	var deserializedBericht bo.Statusbericht
 	err = json.Unmarshal(serializedBericht, &deserializedBericht)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedBericht, is.EqualTo(bericht))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedBericht, is.EqualTo(bericht))
 }
 
 // Test_Successful_Vertrag_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Statusbericht_Validation() {
+func Test_Successful_Statusbericht_Validation(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.STATUSBERICHT).(*bo.Statusbericht)
 	object.Status = berichtstatus.ERFOLGREICH
 	validate := validator.New()
 	validVertrag := []bo.BusinessObject{
 		*object,
 	}
-	VerfiySuccessfulValidations(s, validate, validVertrag)
+	VerifySuccessfulValidations(t, validate, validVertrag)
 }
 
-func (s *Suite) Test_Empty_Statusbericht_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Statusbericht_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.STATUSBERICHT)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Statusbericht{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.STATUSBERICHT))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Statusbericht{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.STATUSBERICHT))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Statusbericht_Contains_No_Enum_Defaults() {

--- a/bo/steuerbareressource_test.go
+++ b/bo/steuerbareressource_test.go
@@ -63,6 +63,6 @@ func Test_Empty_SteuerbarreRessource_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_SteuerbarreRessource_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.STEUERBARERESSOURCE))
+func Test_Serialized_Empty_SteuerbarreRessource_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.STEUERBARERESSOURCE))
 }

--- a/bo/steuerbareressource_test.go
+++ b/bo/steuerbareressource_test.go
@@ -2,12 +2,14 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/bo"
 	"github.com/hochfrequenz/go-bo4e/enum/botyp"
-	"reflect"
 )
 
 var stbressource = bo.SteuerbareRessource{
@@ -22,43 +24,43 @@ var stbressource = bo.SteuerbareRessource{
 }
 
 // Test_Steuerbareressource_Deserialization deserializes an SteuerbareRessource json
-func (s *Suite) Test_Steuerbareressource_Deserialization() {
+func Test_Steuerbareressource_Deserialization(t *testing.T) {
 	serializedStbressource, err := json.Marshal(stbressource)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedStbressource, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedStbressource, is.Not(is.NilArray[byte]()))
 	var deserializedStbressource bo.SteuerbareRessource
 	err = json.Unmarshal(serializedStbressource, &deserializedStbressource)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedStbressource, is.EqualTo(stbressource))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedStbressource, is.EqualTo(stbressource))
 
 }
 
 // Test_Failed_SteuerbarreRessource_Validation verifies that the validators of a SteuerbareRessource work
-func (s *Suite) Test_Failed_SteuerbarreRessource_Validation() {
+func Test_Failed_SteuerbarreRessource_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidStbressource := map[string][]interface{}{
 		"required": {
 			bo.SteuerbareRessource{},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidStbressource)
+	VerifyFailedValidations(t, validate, invalidStbressource)
 }
 
 // Test_Successful_SteuerbarreRessource_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_SteuerbarreRessource_Validation() {
+func Test_Successful_SteuerbarreRessource_Validation(t *testing.T) {
 	validate := validator.New()
 	validSteuerbarreRessource := []bo.BusinessObject{
 		stbressource,
 	}
-	VerfiySuccessfulValidations(s, validate, validSteuerbarreRessource)
+	VerifySuccessfulValidations(t, validate, validSteuerbarreRessource)
 }
 
-func (s *Suite) Test_Empty_SteuerbarreRessource_Is_Creatable_Using_BoTyp() {
+func Test_Empty_SteuerbarreRessource_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.STEUERBARERESSOURCE)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.SteuerbareRessource{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.STEUERBARERESSOURCE))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.SteuerbareRessource{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.STEUERBARERESSOURCE))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_SteuerbarreRessource_Contains_No_Enum_Defaults() {

--- a/bo/technischeressource_test.go
+++ b/bo/technischeressource_test.go
@@ -2,6 +2,9 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -16,7 +19,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/technischeressourceverbrauchsart"
 	"github.com/hochfrequenz/go-bo4e/enum/waermenutzung"
 	"github.com/hochfrequenz/go-bo4e/internal"
-	"reflect"
 )
 
 var tressource = bo.TechnischeRessource{
@@ -50,43 +52,43 @@ var tressource = bo.TechnischeRessource{
 }
 
 // Test_TechnischeRessource_Deserialization deserializes an TechnischeRessource json
-func (s *Suite) Test_TechnischeRessource_Deserialization() {
+func Test_TechnischeRessource_Deserialization(t *testing.T) {
 	serializedTressource, err := json.Marshal(tressource)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedTressource, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedTressource, is.Not(is.NilArray[byte]()))
 	var deserializedTressource bo.TechnischeRessource
 	err = json.Unmarshal(serializedTressource, &deserializedTressource)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedTressource, is.EqualTo(tressource))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedTressource, is.EqualTo(tressource))
 
 }
 
 // Test_Failed_TechnischeRessource_Validation verifies that the validators of a TechnischeRessource work
-func (s *Suite) Test_Failed_TechnischeRessource_Validation() {
+func Test_Failed_TechnischeRessource_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidTressource := map[string][]interface{}{
 		"required": {
 			bo.TechnischeRessource{},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidTressource)
+	VerifyFailedValidations(t, validate, invalidTressource)
 }
 
 // Test_Successful_TechnischeRessource_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_TechnischeRessource_Validation() {
+func Test_Successful_TechnischeRessource_Validation(t *testing.T) {
 	validate := validator.New()
 	validTechnischeRessource := []bo.BusinessObject{
 		tressource,
 	}
-	VerfiySuccessfulValidations(s, validate, validTechnischeRessource)
+	VerifySuccessfulValidations(t, validate, validTechnischeRessource)
 }
 
-func (s *Suite) Test_Empty_TechnischeRessource_Is_Creatable_Using_BoTyp() {
+func Test_Empty_TechnischeRessource_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.TECHNISCHERESSOURCE)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.TechnischeRessource{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.TECHNISCHERESSOURCE))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.TechnischeRessource{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.TECHNISCHERESSOURCE))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_TechnischeRessource_Contains_No_Enum_Defaults() {

--- a/bo/technischeressource_test.go
+++ b/bo/technischeressource_test.go
@@ -91,6 +91,6 @@ func Test_Empty_TechnischeRessource_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_TechnischeRessource_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.TECHNISCHERESSOURCE))
+func Test_Serialized_Empty_TechnischeRessource_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.TECHNISCHERESSOURCE))
 }

--- a/bo/tranche_test.go
+++ b/bo/tranche_test.go
@@ -67,6 +67,6 @@ func Test_Empty_Tranche_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Tranche_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.TRANCHE))
+func Test_Serialized_Empty_Tranche_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.TRANCHE))
 }

--- a/bo/tranche_test.go
+++ b/bo/tranche_test.go
@@ -2,6 +2,9 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -10,7 +13,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"reflect"
 )
 
 var tranche = bo.Tranche{
@@ -26,43 +28,43 @@ var tranche = bo.Tranche{
 }
 
 // Test_Tranche_Deserialization deserializes an Tranche json
-func (s *Suite) Test_Tranche_Deserialization() {
+func Test_Tranche_Deserialization(t *testing.T) {
 	serializedTranche, err := json.Marshal(tranche)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedTranche, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedTranche, is.Not(is.NilArray[byte]()))
 	var deserializedTranche bo.Tranche
 	err = json.Unmarshal(serializedTranche, &deserializedTranche)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedTranche, is.EqualTo(tranche))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedTranche, is.EqualTo(tranche))
 
 }
 
 // Test_Failed_Tranche_Validation verifies that the validators of a Tranche work
-func (s *Suite) Test_Failed_Tranche_Validation() {
+func Test_Failed_Tranche_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidTranche := map[string][]interface{}{
 		"required": {
 			bo.Tranche{},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidTranche)
+	VerifyFailedValidations(t, validate, invalidTranche)
 }
 
 // Test_Successful_Tranche_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Tranche_Validation() {
+func Test_Successful_Tranche_Validation(t *testing.T) {
 	validate := validator.New()
 	validTranche := []bo.BusinessObject{
 		tranche,
 	}
-	VerfiySuccessfulValidations(s, validate, validTranche)
+	VerifySuccessfulValidations(t, validate, validTranche)
 }
 
-func (s *Suite) Test_Empty_Tranche_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Tranche_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.TRANCHE)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Tranche{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.TRANCHE))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Tranche{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.TRANCHE))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Tranche_Contains_No_Enum_Defaults() {

--- a/bo/vertrag_test.go
+++ b/bo/vertrag_test.go
@@ -195,6 +195,6 @@ func Test_Empty_Vertrag_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Vertrag_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.VERTRAG))
+func Test_Serialized_Empty_Vertrag_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.VERTRAG))
 }

--- a/bo/vertrag_test.go
+++ b/bo/vertrag_test.go
@@ -2,6 +2,10 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -16,12 +20,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/vertragsstatus"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"time"
 )
 
 // Test_Vertragspartner_Deserialization deserializes an Vertrag json
-func (s *Suite) Test_Vertrag_Deserialization() {
+func Test_Vertrag_Deserialization(t *testing.T) {
 	var contract = bo.Vertrag{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
 			BoTyp:             botyp.VERTRAG,
@@ -88,16 +90,16 @@ func (s *Suite) Test_Vertrag_Deserialization() {
 		Gemeinderabatt: decimal.NewNullDecimal(decimal.NewFromInt(50)),
 	}
 	serializedContract, err := json.Marshal(contract)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedContract, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedContract, is.Not(is.NilArray[byte]()))
 	var deserializedVertrag bo.Vertrag
 	err = json.Unmarshal(serializedContract, &deserializedVertrag)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedVertrag, is.EqualTo(contract))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedVertrag, is.EqualTo(contract))
 }
 
 // TestFailedGVertragValidation verifies that the validators of a Vertrag work
-func (s *Suite) Test_Failed_VertragValidation() {
+func Test_Failed_VertragValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVertrags := map[string][]interface{}{
 		"required": {
@@ -110,11 +112,11 @@ func (s *Suite) Test_Failed_VertragValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVertrags)
+	VerifyFailedValidations(t, validate, invalidVertrags)
 }
 
 // Test_Successful_Vertrag_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Vertrag_Validation() {
+func Test_Successful_Vertrag_Validation(t *testing.T) {
 
 	validate := validator.New()
 	validVertrag := []bo.BusinessObject{
@@ -182,15 +184,15 @@ func (s *Suite) Test_Successful_Vertrag_Validation() {
 			Gemeinderabatt: decimal.NewNullDecimal(decimal.NewFromInt(50)),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validVertrag)
+	VerifySuccessfulValidations(t, validate, validVertrag)
 }
 
-func (s *Suite) Test_Empty_Vertrag_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Vertrag_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.VERTRAG)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Vertrag{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.VERTRAG))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Vertrag{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.VERTRAG))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Vertrag_Contains_No_Enum_Defaults() {

--- a/bo/zaehler_test.go
+++ b/bo/zaehler_test.go
@@ -152,6 +152,6 @@ func Test_Empty_Zaehler_Is_Creatable_Using_BoTyp(t *testing.T) {
 	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
-func (s *Suite) Test_Serialized_Empty_Zaehler_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(bo.NewBusinessObject(botyp.ZAEHLER))
+func Test_Serialized_Empty_Zaehler_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.ZAEHLER))
 }

--- a/bo/zaehler_test.go
+++ b/bo/zaehler_test.go
@@ -2,6 +2,10 @@ package bo_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -18,12 +22,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/zaehlertyp"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"reflect"
-	"strings"
 )
 
 // Test_Zaehler_Deserialization deserializes an Zaehler json
-func (s *Suite) Test_Zaehler_Deserialization() {
+func Test_Zaehler_Deserialization(t *testing.T) {
 	var meter = bo.Zaehler{
 		Geschaeftsobjekt: bo.Geschaeftsobjekt{
 			BoTyp:             botyp.ZAEHLER,
@@ -49,22 +51,22 @@ func (s *Suite) Test_Zaehler_Deserialization() {
 		Zaehlerhersteller: nil,
 	}
 	serializedMeter, err := json.Marshal(meter)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedMeter, is.Not(is.NilArray[byte]()))
-	then.AssertThat(s.T(), strings.Contains(string(serializedMeter), "EINTARIF"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serializedMeter), "EINRICHTUNGSZAEHLER"), is.True())
-	then.AssertThat(s.T(), strings.Contains(string(serializedMeter), "EINTARIF"), is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedMeter, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(string(serializedMeter), "EINTARIF"), is.True())
+	then.AssertThat(t, strings.Contains(string(serializedMeter), "EINRICHTUNGSZAEHLER"), is.True())
+	then.AssertThat(t, strings.Contains(string(serializedMeter), "EINTARIF"), is.True())
 	var deserializedMeter bo.Zaehler
 	err = json.Unmarshal(serializedMeter, &deserializedMeter)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 
 	areEqual, err := internal.CompareAsJson(meter, deserializedMeter)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), areEqual, is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, areEqual, is.True())
 }
 
 // TestFailedZaehlerValidation verifies that the validators of a Zaehler work
-func (s *Suite) Test_Failed_ZaehlerValidation() {
+func Test_Failed_ZaehlerValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVertrags := map[string][]interface{}{
 		"required": {
@@ -88,11 +90,11 @@ func (s *Suite) Test_Failed_ZaehlerValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVertrags)
+	VerifyFailedValidations(t, validate, invalidVertrags)
 }
 
 // Test_Successful_Zaehler_Validation verifies that a valid BO is validated without errors
-func (s *Suite) Test_Successful_Zaehler_Validation() {
+func Test_Successful_Zaehler_Validation(t *testing.T) {
 	validate := validator.New()
 	validZaehler := []bo.BusinessObject{
 		bo.Zaehler{
@@ -139,15 +141,15 @@ func (s *Suite) Test_Successful_Zaehler_Validation() {
 			},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validZaehler)
+	VerifySuccessfulValidations(t, validate, validZaehler)
 }
 
-func (s *Suite) Test_Empty_Zaehler_Is_Creatable_Using_BoTyp() {
+func Test_Empty_Zaehler_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.ZAEHLER)
-	then.AssertThat(s.T(), object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Zaehler{})))
-	then.AssertThat(s.T(), object.GetBoTyp(), is.EqualTo(botyp.ZAEHLER))
-	then.AssertThat(s.T(), object.GetVersionStruktur(), is.EqualTo("1.1"))
+	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, reflect.TypeOf(object), is.EqualTo(reflect.TypeOf(&bo.Zaehler{})))
+	then.AssertThat(t, object.GetBoTyp(), is.EqualTo(botyp.ZAEHLER))
+	then.AssertThat(t, object.GetVersionStruktur(), is.EqualTo("1.1"))
 }
 
 func (s *Suite) Test_Serialized_Empty_Zaehler_Contains_No_Enum_Defaults() {

--- a/com/abweichung_test.go
+++ b/com/abweichung_test.go
@@ -61,6 +61,6 @@ func Test_UnSuccessful_Abweichung_Validation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidAbweichung)
 }
 
-func (s *Suite) Test_Serialized_Empty_Abweichung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Abweichung{})
+func Test_Serialized_Empty_Abweichung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Abweichung{})
 }

--- a/com/abweichung_test.go
+++ b/com/abweichung_test.go
@@ -3,6 +3,7 @@ package com_test
 import (
 	"encoding/json"
 	"strings"
+	"testing"
 
 	"github.com/go-playground/validator/v10"
 
@@ -13,7 +14,7 @@ import (
 )
 
 // Test_Deserialization deserializes an abweichung json
-func (s *Suite) Test_Abweichung_Deserialization() {
+func Test_Abweichung_Deserialization(t *testing.T) {
 	ungleichVertragsbeginn := abweichungsgrund.ABRECHNUNGSBEGINN_UNGLEICH_VERTRAGSBEGINN
 	bemerkung := "BBBB"
 	code := "A99"
@@ -25,18 +26,18 @@ func (s *Suite) Test_Abweichung_Deserialization() {
 		AbweichungsgrundCodeliste: &codeliste,
 	}
 	serializedAbweichung, err := json.Marshal(abweichung)
-	then.AssertThat(s.T(), serializedAbweichung, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, serializedAbweichung, is.Not(is.NilArray[byte]()))
 	jsonString := string(serializedAbweichung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ZZZZ"), is.False())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, strings.Contains(jsonString, "ZZZZ"), is.False())
 	deserializedAbweichung := com.Abweichung{}
 	err = json.Unmarshal(serializedAbweichung, &deserializedAbweichung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedAbweichung, is.EqualTo(abweichung))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedAbweichung, is.EqualTo(abweichung))
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid Abweichung
-func (s *Suite) Test_Successful_Abweichung_Validation() {
+func Test_Successful_Abweichung_Validation(t *testing.T) {
 	validate := validator.New()
 	bilanzierteMengeFehlt := abweichungsgrund.BILANZIERTE_MENGE_FEHLT
 	validAbweichung := []interface{}{
@@ -44,10 +45,10 @@ func (s *Suite) Test_Successful_Abweichung_Validation() {
 			AbweichungsGrund: &bilanzierteMengeFehlt,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAbweichung)
+	VerifySuccessfulValidations(t, validate, validAbweichung)
 }
 
-func (s *Suite) Test_UnSuccessful_Abweichung_Validation() {
+func Test_UnSuccessful_Abweichung_Validation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.AbweichungStructLevelValidation, com.Abweichung{})
 	code := "A99"
@@ -57,7 +58,7 @@ func (s *Suite) Test_UnSuccessful_Abweichung_Validation() {
 			AbweichungsgrundCode: &code,
 		}},
 	}
-	VerfiyFailedValidations(s, validate, invalidAbweichung)
+	VerifyFailedValidations(t, validate, invalidAbweichung)
 }
 
 func (s *Suite) Test_Serialized_Empty_Abweichung_Contains_No_Enum_Defaults() {

--- a/com/adresse_test.go
+++ b/com/adresse_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Test_Deserialization deserializes an address json
-func (s *Suite) Test_Address_Deserialization() {
+func Test_Address_Deserialization(t *testing.T) {
 	var adresse = com.Adresse{
 		Postleitzahl: "82031",
 		Ort:          "Grünwald",
@@ -27,18 +27,18 @@ func (s *Suite) Test_Address_Deserialization() {
 	}
 	serializedAdresse, err := json.Marshal(adresse)
 	jsonString := string(serializedAdresse)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "DE"), is.True())                              // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, strconv.Itoa(int(landescode.DE))), is.False()) // no raw int enum value
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedAdresse, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "DE"), is.True())                              // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, strconv.Itoa(int(landescode.DE))), is.False()) // no raw int enum value
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedAdresse, is.Not(is.NilArray[byte]()))
 	var deserializedAdresse com.Adresse
 	err = json.Unmarshal(serializedAdresse, &deserializedAdresse)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedAdresse, is.EqualTo(adresse))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedAdresse, is.EqualTo(adresse))
 }
 
 // Test_StrasseXorPostfach_Validation verifies that the Strasse XOR Postfach validation works
-func (s *Suite) Test_Strasse_XorPostfachValidation() {
+func Test_Strasse_XorPostfachValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.AdresseStructLevelValidation, com.Adresse{})
 	invalidAdressMaps := map[string][]interface{}{
@@ -83,11 +83,11 @@ func (s *Suite) Test_Strasse_XorPostfachValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidAdressMaps)
+	VerifyFailedValidations(t, validate, invalidAdressMaps)
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid Adresse
-func (s *Suite) Test_Successful_Adresse_Validation() {
+func Test_Successful_Adresse_Validation(t *testing.T) {
 	validate := validator.New()
 	validAddresses := []interface{}{
 		com.Adresse{
@@ -98,7 +98,7 @@ func (s *Suite) Test_Successful_Adresse_Validation() {
 			Landescode:   internal.Ptr(landescode.DE),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAddresses)
+	VerifySuccessfulValidations(t, validate, validAddresses)
 }
 
 func Test_Serialized_Empty_Adresse_Contains_No_Enum_Defaults(t *testing.T) {

--- a/com/adresse_test.go
+++ b/com/adresse_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"testing"
 
 	"github.com/hochfrequenz/go-bo4e/internal"
 
@@ -100,13 +101,6 @@ func (s *Suite) Test_Successful_Adresse_Validation() {
 	VerfiySuccessfulValidations(s, validate, validAddresses)
 }
 
-func (s *Suite) Test_Serialized_Empty_Adresse_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Adresse{})
-}
-
-func (s *Suite) assert_Does_Not_Serialize_Default_Enums(com interface{}) {
-	jsonBytes, err := json.Marshal(com)
-	then.AssertThat(s.T(), err, is.Nil())
-	jsonString := string(jsonBytes)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "(0)"), is.False())
+func Test_Serialized_Empty_Adresse_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Adresse{})
 }

--- a/com/avisposition_test.go
+++ b/com/avisposition_test.go
@@ -72,6 +72,6 @@ func Test_Successful_AvisPosition_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validAvisPosition)
 }
 
-func (s *Suite) Test_Serialized_Empty_AvisPosition_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.AvisPosition{})
+func Test_Serialized_Empty_AvisPosition_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.AvisPosition{})
 }

--- a/com/avisposition_test.go
+++ b/com/avisposition_test.go
@@ -3,6 +3,7 @@ package com_test
 import (
 	"encoding/json"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/corbym/gocrest/is"
@@ -15,7 +16,7 @@ import (
 )
 
 // Test_Deserialization deserializes an avisposition json
-func (s *Suite) Test_AvisPosition_Deserialization() {
+func Test_AvisPosition_Deserialization(t *testing.T) {
 	avisPosition := com.AvisPosition{
 		RechnungsNummer: "AAAA",
 		RechnungsDatum:  time.Date(2022, 8, 1, 0, 0, 0, 0, time.UTC),
@@ -30,19 +31,19 @@ func (s *Suite) Test_AvisPosition_Deserialization() {
 		},
 	}
 	serializedAvisPosition, err := json.Marshal(avisPosition)
-	then.AssertThat(s.T(), serializedAvisPosition, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, serializedAvisPosition, is.Not(is.NilArray[byte]()))
 	jsonString := string(serializedAvisPosition)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), strings.Contains(jsonString, "AAAA"), is.True())
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ZZZZ"), is.False())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, strings.Contains(jsonString, "AAAA"), is.True())
+	then.AssertThat(t, strings.Contains(jsonString, "ZZZZ"), is.False())
 	deserializedAvisPosition := com.AvisPosition{}
 	err = json.Unmarshal(serializedAvisPosition, &deserializedAvisPosition)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedAvisPosition, is.EqualTo(avisPosition))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedAvisPosition, is.EqualTo(avisPosition))
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid AvisPosition
-func (s *Suite) Test_Successful_AvisPosition_Validation() {
+func Test_Successful_AvisPosition_Validation(t *testing.T) {
 	bemerkung := "CCCC"
 	validate := validator.New()
 	ungleichVertragsbeginn := abweichungsgrund.ABRECHNUNGSBEGINN_UNGLEICH_VERTRAGSBEGINN
@@ -68,7 +69,7 @@ func (s *Suite) Test_Successful_AvisPosition_Validation() {
 			},
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAvisPosition)
+	VerifySuccessfulValidations(t, validate, validAvisPosition)
 }
 
 func (s *Suite) Test_Serialized_Empty_AvisPosition_Contains_No_Enum_Defaults() {

--- a/com/betrag_test.go
+++ b/com/betrag_test.go
@@ -43,6 +43,6 @@ func Test_Successful_BetragValidation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validBetraege)
 }
 
-func (s *Suite) Test_Serialized_Empty_Betrag_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Betrag{})
+func Test_Serialized_Empty_Betrag_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Betrag{})
 }

--- a/com/betrag_test.go
+++ b/com/betrag_test.go
@@ -1,6 +1,8 @@
 package com_test
 
 import (
+	"testing"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungscode"
@@ -8,7 +10,7 @@ import (
 )
 
 // TestFailedBetragValidation asserts that the validation fails, if not both Betrag.Wert and Betrag.Waehrung are provided
-func (s *Suite) Test_Failed_BetragValidation() {
+func Test_Failed_BetragValidation(t *testing.T) {
 	validate := validator.New()
 	invalidBetragMap := map[string][]interface{}{
 		"required": {
@@ -22,11 +24,11 @@ func (s *Suite) Test_Failed_BetragValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidBetragMap)
+	VerifyFailedValidations(t, validate, invalidBetragMap)
 }
 
 // TestSuccessfulBetragValidation asserts that the validation does not fail for a valid Betrag
-func (s *Suite) Test_Successful_BetragValidation() {
+func Test_Successful_BetragValidation(t *testing.T) {
 	validate := validator.New()
 	validBetraege := []interface{}{
 		com.Betrag{
@@ -38,7 +40,7 @@ func (s *Suite) Test_Successful_BetragValidation() {
 			Waehrung: waehrungscode.ANG,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validBetraege)
+	VerifySuccessfulValidations(t, validate, validBetraege)
 }
 
 func (s *Suite) Test_Serialized_Empty_Betrag_Contains_No_Enum_Defaults() {

--- a/com/externe_referenz_test.go
+++ b/com/externe_referenz_test.go
@@ -1,12 +1,14 @@
 package com_test
 
 import (
+	"testing"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 )
 
 // TestFailedExterneReferenzValidation asserts that the validation fails, if not both name and value are provided
-func (s *Suite) Test_Failed_ExterneReferenzValidation() {
+func Test_Failed_ExterneReferenzValidation(t *testing.T) {
 	validate := validator.New()
 	invalidReferenzMap := map[string][]interface{}{
 		"required": {
@@ -24,11 +26,11 @@ func (s *Suite) Test_Failed_ExterneReferenzValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidReferenzMap)
+	VerifyFailedValidations(t, validate, invalidReferenzMap)
 }
 
 // TestSuccessfulExterneReferenzValidation asserts that the validation does not fail for a valid ExterneReferenz
-func (s *Suite) Test_Successful_ExterneReferenzValidation() {
+func Test_Successful_ExterneReferenzValidation(t *testing.T) {
 	validate := validator.New()
 	validReferences := []interface{}{
 		com.ExterneReferenz{
@@ -36,7 +38,7 @@ func (s *Suite) Test_Successful_ExterneReferenzValidation() {
 			ExRefWert: "bar",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validReferences)
+	VerifySuccessfulValidations(t, validate, validReferences)
 }
 
 func (s *Suite) Test_Serialized_Empty_Externe_Referenz_Contains_No_Enum_Defaults() {

--- a/com/externe_referenz_test.go
+++ b/com/externe_referenz_test.go
@@ -41,6 +41,6 @@ func Test_Successful_ExterneReferenzValidation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validReferences)
 }
 
-func (s *Suite) Test_Serialized_Empty_Externe_Referenz_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.ExterneReferenz{})
+func Test_Serialized_Empty_Externe_Referenz_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.ExterneReferenz{})
 }

--- a/com/lastprofil_test.go
+++ b/com/lastprofil_test.go
@@ -1,12 +1,14 @@
 package com_test
 
 import (
+	"testing"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 )
 
 // Test_Failed_Lastprofil_Validation asserts that the validation fails for invalid Lastprofil
-func (s *Suite) Test_Failed_Lastprofil_Validation() {
+func Test_Failed_Lastprofil_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidLastprofile := map[string][]interface{}{
 		"alphanum": {
@@ -20,11 +22,11 @@ func (s *Suite) Test_Failed_Lastprofil_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidLastprofile)
+	VerifyFailedValidations(t, validate, invalidLastprofile)
 }
 
 // Test_Successful_Lastprofil_Validation asserts that the validation does not fail for a valid Lastprofil
-func (s *Suite) Test_Successful_Lastprofil_Validation() {
+func Test_Successful_Lastprofil_Validation(t *testing.T) {
 	validate := validator.New()
 	validLastprofile := []interface{}{
 		com.Lastprofil{}, // by default nothing is required
@@ -33,5 +35,5 @@ func (s *Suite) Test_Successful_Lastprofil_Validation() {
 			Herausgeber: "BDEW",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validLastprofile)
+	VerifySuccessfulValidations(t, validate, validLastprofile)
 }

--- a/com/menge_test.go
+++ b/com/menge_test.go
@@ -2,6 +2,9 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,28 +12,27 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"strings"
 )
 
 // Test_Menge_Deserialization deserializes an Menge json
-func (s *Suite) Test_Menge_Deserialization() {
+func Test_Menge_Deserialization(t *testing.T) {
 	var menge = com.Menge{
 		Wert:    decimal.NewFromFloat(42),
 		Einheit: internal.Ptr(mengeneinheit.KUBIKMETER),
 	}
 	serializedMenge, err := json.Marshal(menge)
 	jsonString := string(serializedMenge)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "KUBIKMETER"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedMenge, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "KUBIKMETER"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedMenge, is.Not(is.NilArray[byte]()))
 	var deserializedVerbrauch com.Menge
 	err = json.Unmarshal(serializedMenge, &deserializedVerbrauch)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedVerbrauch, is.EqualTo[com.Menge](menge))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedVerbrauch, is.EqualTo[com.Menge](menge))
 }
 
 // Test_Successful_Menge_Validation asserts that the validation does not fail for a valid Menge
-func (s *Suite) Test_Successful_Menge_Validation() {
+func Test_Successful_Menge_Validation(t *testing.T) {
 	validate := validator.New()
 	validMenges := []interface{}{
 		com.Menge{
@@ -42,11 +44,11 @@ func (s *Suite) Test_Successful_Menge_Validation() {
 			Einheit: internal.Ptr(mengeneinheit.W),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validMenges)
+	VerifySuccessfulValidations(t, validate, validMenges)
 }
 
 // TestMengeFailedValidation verifies that invalid verbrauch values are considered invalid
-func (s *Suite) Test_Menge_FailedValidation() {
+func Test_Menge_FailedValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVerbrauchMap := map[string][]interface{}{
 		"required": {
@@ -56,7 +58,7 @@ func (s *Suite) Test_Menge_FailedValidation() {
 			com.Menge{},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVerbrauchMap)
+	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
 func (s *Suite) Test_Serialized_Empty_Menge_Contains_No_Enum_Defaults() {

--- a/com/menge_test.go
+++ b/com/menge_test.go
@@ -61,6 +61,6 @@ func Test_Menge_FailedValidation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
-func (s *Suite) Test_Serialized_Empty_Menge_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Menge{})
+func Test_Serialized_Empty_Menge_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Menge{})
 }

--- a/com/messlokationszuordnung_test.go
+++ b/com/messlokationszuordnung_test.go
@@ -78,6 +78,6 @@ func Test_Successful_Messlokationszuordnung_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validMesslokationszuordnung)
 }
 
-func (s *Suite) Test_Serialized_Empty_Messlokationszuordnung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Messlokationszuordnung{})
+func Test_Serialized_Empty_Messlokationszuordnung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Messlokationszuordnung{})
 }

--- a/com/messlokationszuordnung_test.go
+++ b/com/messlokationszuordnung_test.go
@@ -2,17 +2,19 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/arithmetischeoperation"
-	"strings"
-	"time"
 )
 
 // Test_Messlokationszuordnung_Deserialization deserializes an MesslokationszuordnungMesslokationszuordnung json
-func (s *Suite) Test_Messlokationszuordnung_Deserialization() {
+func Test_Messlokationszuordnung_Deserialization(t *testing.T) {
 	var messlokationszuordnung = com.Messlokationszuordnung{
 		MesslokationsId: "DE0123456789012345678901234567890",
 		Arithmetik:      arithmetischeoperation.ADDITION,
@@ -20,20 +22,20 @@ func (s *Suite) Test_Messlokationszuordnung_Deserialization() {
 		GueltigBis:      time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
 	}
 	serializedMesslokationszuordnung, err := json.Marshal(messlokationszuordnung)
-	then.AssertThat(s.T(), serializedMesslokationszuordnung, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, serializedMesslokationszuordnung, is.Not(is.NilArray[byte]()))
 
 	jsonString := string(serializedMesslokationszuordnung)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ADDITION"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, strings.Contains(jsonString, "ADDITION"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
 
 	var deserializedMesslokationszuordnung com.Messlokationszuordnung
 	err = json.Unmarshal(serializedMesslokationszuordnung, &deserializedMesslokationszuordnung)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedMesslokationszuordnung, is.EqualTo(messlokationszuordnung))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedMesslokationszuordnung, is.EqualTo(messlokationszuordnung))
 }
 
 // Test_Failed_Validation asserts that the validation fails for invalid Messlokationszuordnung
-func (s *Suite) Test_Failed_MesslokationszuordnungValidation() {
+func Test_Failed_MesslokationszuordnungValidation(t *testing.T) {
 	validate := validator.New()
 	invalidMesslokationszuordnung := map[string][]interface{}{
 		"required": {
@@ -55,11 +57,11 @@ func (s *Suite) Test_Failed_MesslokationszuordnungValidation() {
 				GueltigBis:  time.Date(2021, 4, 1, 0, 0, 0, 0, time.UTC)},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidMesslokationszuordnung)
+	VerifyFailedValidations(t, validate, invalidMesslokationszuordnung)
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid Messlokationszuordnung
-func (s *Suite) Test_Successful_Messlokationszuordnung_Validation() {
+func Test_Successful_Messlokationszuordnung_Validation(t *testing.T) {
 	validate := validator.New()
 	validMesslokationszuordnung := []interface{}{
 		com.Messlokationszuordnung{
@@ -73,7 +75,7 @@ func (s *Suite) Test_Successful_Messlokationszuordnung_Validation() {
 			GueltigBis:      time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validMesslokationszuordnung)
+	VerifySuccessfulValidations(t, validate, validMesslokationszuordnung)
 }
 
 func (s *Suite) Test_Serialized_Empty_Messlokationszuordnung_Contains_No_Enum_Defaults() {

--- a/com/netznutzungsabrechnungsdaten_test.go
+++ b/com/netznutzungsabrechnungsdaten_test.go
@@ -58,6 +58,6 @@ func Test_Successful_Netznutzungsabrechnungsdaten_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validNetznutzungsabrechnungsdaten)
 }
 
-func (s *Suite) Test_Serialized_Empty_Netznutzungsabrechnungsdaten_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Netznutzungsabrechnungsdaten{})
+func Test_Serialized_Empty_Netznutzungsabrechnungsdaten_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Netznutzungsabrechnungsdaten{})
 }

--- a/com/netznutzungsabrechnungsdaten_test.go
+++ b/com/netznutzungsabrechnungsdaten_test.go
@@ -2,6 +2,8 @@ package com_test
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -13,7 +15,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func (s *Suite) Test_Netznutzungsabrechnungsdaten_Deserialization() {
+func Test_Netznutzungsabrechnungsdaten_Deserialization(t *testing.T) {
 	artikelId := "foo"
 	artikelIdTyp := artikelidtyp.GRUPPENARTIKELID
 	anzahl := 17
@@ -37,23 +39,23 @@ func (s *Suite) Test_Netznutzungsabrechnungsdaten_Deserialization() {
 	}
 
 	serializedNnad, err := json.Marshal(netznutzungsabrechnungsdaten)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedNnad, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedNnad, is.Not(is.NilArray[byte]()))
 
 	var deserializedNnad com.Netznutzungsabrechnungsdaten
 	err = json.Unmarshal(serializedNnad, &deserializedNnad)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedNnad, is.EqualTo(netznutzungsabrechnungsdaten))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedNnad, is.EqualTo(netznutzungsabrechnungsdaten))
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid Netznutzungsabrechnungsdaten
-func (s *Suite) Test_Successful_Netznutzungsabrechnungsdaten_Validation() {
+func Test_Successful_Netznutzungsabrechnungsdaten_Validation(t *testing.T) {
 	validate := validator.New()
 	validNetznutzungsabrechnungsdaten := []interface{}{
 		com.Netznutzungsabrechnungsdaten{},
 		// add more when there's something like a serious validation. as of now, all fields are optional
 	}
-	VerfiySuccessfulValidations(s, validate, validNetznutzungsabrechnungsdaten)
+	VerifySuccessfulValidations(t, validate, validNetznutzungsabrechnungsdaten)
 }
 
 func (s *Suite) Test_Serialized_Empty_Netznutzungsabrechnungsdaten_Contains_No_Enum_Defaults() {

--- a/com/preis_test.go
+++ b/com/preis_test.go
@@ -73,6 +73,6 @@ func Test_Preis_FailedValidation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidPrices)
 }
 
-func (s *Suite) Test_Serialized_Empty_Preis_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Preis{})
+func Test_Serialized_Empty_Preis_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Preis{})
 }

--- a/com/preis_test.go
+++ b/com/preis_test.go
@@ -2,6 +2,9 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -10,11 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/preisstatus"
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungseinheit"
 	"github.com/shopspring/decimal"
-	"strings"
 )
 
 // Test_Preis_Deserialization deserializes an Preis json
-func (s *Suite) Test_Preis_Deserialization() {
+func Test_Preis_Deserialization(t *testing.T) {
 	var preis = com.Preis{
 		Wert:       decimal.NewFromFloat(17.89),
 		Einheit:    waehrungseinheit.EUR,
@@ -23,19 +25,19 @@ func (s *Suite) Test_Preis_Deserialization() {
 	}
 	serializedPreis, err := json.Marshal(preis)
 	jsonString := string(serializedPreis)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "MONAT"), is.True())      // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ENDGUELTIG"), is.True()) // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "EUR"), is.True())        // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedPreis, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "MONAT"), is.True())      // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "ENDGUELTIG"), is.True()) // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "EUR"), is.True())        // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedPreis, is.Not(is.NilArray[byte]()))
 	var deserializedPreis com.Preis
 	err = json.Unmarshal(serializedPreis, &deserializedPreis)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedPreis, is.EqualTo(preis))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedPreis, is.EqualTo(preis))
 }
 
 // Test_Successful_Preis_Validation asserts that the validation does not fail for a valid Preis
-func (s *Suite) Test_Successful_Preis_Validation() {
+func Test_Successful_Preis_Validation(t *testing.T) {
 	validate := validator.New()
 	validPrices := []interface{}{
 		com.Preis{
@@ -51,11 +53,11 @@ func (s *Suite) Test_Successful_Preis_Validation() {
 			// status is not obligatory
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validPrices)
+	VerifySuccessfulValidations(t, validate, validPrices)
 }
 
 // TestPreisFailedValidation verifies that invalid Preis values are considered invalid
-func (s *Suite) Test_Preis_FailedValidation() {
+func Test_Preis_FailedValidation(t *testing.T) {
 	validate := validator.New()
 	invalidPrices := map[string][]interface{}{
 		"required": {
@@ -68,7 +70,7 @@ func (s *Suite) Test_Preis_FailedValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidPrices)
+	VerifyFailedValidations(t, validate, invalidPrices)
 }
 
 func (s *Suite) Test_Serialized_Empty_Preis_Contains_No_Enum_Defaults() {

--- a/com/rechnungsposition_test.go
+++ b/com/rechnungsposition_test.go
@@ -3,6 +3,7 @@ package com_test
 import (
 	"encoding/json"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/hochfrequenz/go-bo4e/internal"
@@ -24,7 +25,7 @@ import (
 var korrekturfaktor float32 = -1
 
 // Test_Rechnungsposition_Deserialization deserializes an Rechnungsposition json
-func (s *Suite) Test_Rechnungsposition_Deserialization() {
+func Test_Rechnungsposition_Deserialization(t *testing.T) {
 	var rechnungsposition = com.Rechnungsposition{
 		Positionsnummer: 17,
 		LieferungVon:    time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),
@@ -62,17 +63,17 @@ func (s *Suite) Test_Rechnungsposition_Deserialization() {
 	}
 	serializedRechnungsposition, err := json.Marshal(rechnungsposition)
 	jsonString := string(serializedRechnungsposition)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ABGABE_KWKG"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedRechnungsposition, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "ABGABE_KWKG"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedRechnungsposition, is.Not(is.NilArray[byte]()))
 	var deserializedRechnungsposition com.Rechnungsposition
 	err = json.Unmarshal(serializedRechnungsposition, &deserializedRechnungsposition)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedRechnungsposition, is.EqualTo(rechnungsposition))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedRechnungsposition, is.EqualTo(rechnungsposition))
 }
 
 // TestFailedRechnungspositionValidation asserts that the validation fails for invalid Rechnungsposition
-func (s *Suite) Test_Failed_RechnungspositionValidation() {
+func Test_Failed_RechnungspositionValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.RechnungspositionStructLevelValidation, com.Rechnungsposition{})
 	invalidRechnungsposition := map[string][]interface{}{
@@ -140,11 +141,11 @@ func (s *Suite) Test_Failed_RechnungspositionValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidRechnungsposition)
+	VerifyFailedValidations(t, validate, invalidRechnungsposition)
 }
 
 // TestSuccessfulRechnungspositionValidation asserts that the validation does not fail for a valid Rechnungsposition
-func (s *Suite) Test_Successful_RechnungspositionValidation() {
+func Test_Successful_RechnungspositionValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.RechnungspositionStructLevelValidation, com.Rechnungsposition{})
 	validRechnungsposition := []interface{}{
@@ -179,7 +180,7 @@ func (s *Suite) Test_Successful_RechnungspositionValidation() {
 			TeilrabattNetto: nil,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validRechnungsposition)
+	VerifySuccessfulValidations(t, validate, validRechnungsposition)
 }
 
 func (s *Suite) Test_Serialized_Empty_Rechnungspositionen_Contains_No_Enum_Defaults() {

--- a/com/rechnungsposition_test.go
+++ b/com/rechnungsposition_test.go
@@ -183,6 +183,6 @@ func Test_Successful_RechnungspositionValidation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validRechnungsposition)
 }
 
-func (s *Suite) Test_Serialized_Empty_Rechnungspositionen_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Rechnungsposition{})
+func Test_Serialized_Empty_Rechnungspositionen_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Rechnungsposition{})
 }

--- a/com/setup_test.go
+++ b/com/setup_test.go
@@ -21,30 +21,40 @@ func TestInit(t *testing.T) {
 
 // VerfiySuccessfulValidations asserts that the vali validator does not fail for all objects provided
 func VerfiySuccessfulValidations(s *Suite, vali *validator.Validate, validObjects []interface{}) {
+	VerifySuccessfulValidations(s.T(), vali, validObjects)
+}
+
+// VerifySuccessfulValidations asserts that the vali validator does not fail for all objects provided
+func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []interface{}) {
 	// ToDo: use generics as soon as golangs allows to
 	for _, validObject := range validObjects {
 		err := vali.Struct(validObject)
-		then.AssertThat(s.T(), err, is.Nil())
+		then.AssertThat(t, err, is.Nil())
 	}
 }
 
 // VerfiyFailedValidations asserts that the vali validator fails with the expected tag for every object
 func VerfiyFailedValidations(s *Suite, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {
+	VerifyFailedValidations(s.T(), vali, tagInvalidObjectsMap)
+}
+
+// VerifyFailedValidations asserts that the vali validator fails with the expected tag for every object
+func VerifyFailedValidations(t *testing.T, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {
 	// ToDo: use generics as soon as golangs allows to
 	for validationTag, invalidObjects := range tagInvalidObjectsMap {
 		for _, invalidObject := range invalidObjects {
 			err := vali.Struct(invalidObject)
-			then.AssertThat(s.T(), err, is.Not(is.Nil()))
+			then.AssertThat(t, err, is.Not(is.Nil()))
 			tagFound := false
 			for _, validationError := range err.(validator.ValidationErrors) {
-				then.AssertThat(s.T(), validationError, is.Not(is.EqualTo[validator.FieldError](nil)))
+				then.AssertThat(t, validationError, is.Not(is.EqualTo[validator.FieldError](nil)))
 				// sometimes there's more than one tag/validation error
 				if validationError.Tag() == validationTag {
 					tagFound = true
 					break
 				}
 			}
-			then.AssertThat(s.T(), tagFound, is.True())
+			then.AssertThat(t, tagFound, is.True())
 		}
 	}
 }

--- a/com/setup_test.go
+++ b/com/setup_test.go
@@ -21,11 +21,6 @@ func TestInit(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-// VerfiySuccessfulValidations asserts that the vali validator does not fail for all objects provided
-func VerfiySuccessfulValidations(s *Suite, vali *validator.Validate, validObjects []interface{}) {
-	VerifySuccessfulValidations(s.T(), vali, validObjects)
-}
-
 // VerifySuccessfulValidations asserts that the vali validator does not fail for all objects provided
 func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []interface{}) {
 	// ToDo: use generics as soon as golangs allows to
@@ -33,11 +28,6 @@ func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validOb
 		err := vali.Struct(validObject)
 		then.AssertThat(t, err, is.Nil())
 	}
-}
-
-// VerfiyFailedValidations asserts that the vali validator fails with the expected tag for every object
-func VerfiyFailedValidations(s *Suite, vali *validator.Validate, tagInvalidObjectsMap map[string][]interface{}) {
-	VerifyFailedValidations(s.T(), vali, tagInvalidObjectsMap)
 }
 
 // VerifyFailedValidations asserts that the vali validator fails with the expected tag for every object

--- a/com/setup_test.go
+++ b/com/setup_test.go
@@ -1,7 +1,9 @@
 package com_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/corbym/gocrest/is"
@@ -68,4 +70,11 @@ func newDecimalFromString(s string) decimal.Decimal {
 		panic(fmt.Errorf("Error while converting '%s'", s))
 	}
 	return result
+}
+
+func assertDoesNotSerializeDefaultEnums(t *testing.T, com interface{}) {
+	jsonBytes, err := json.Marshal(com)
+	then.AssertThat(t, err, is.Nil())
+	jsonString := string(jsonBytes)
+	then.AssertThat(t, strings.Contains(jsonString, "(0)"), is.False())
 }

--- a/com/setup_test.go
+++ b/com/setup_test.go
@@ -10,16 +10,7 @@ import (
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
 	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/suite"
 )
-
-type Suite struct {
-	suite.Suite
-}
-
-func TestInit(t *testing.T) {
-	suite.Run(t, new(Suite))
-}
 
 // VerifySuccessfulValidations asserts that the vali validator does not fail for all objects provided
 func VerifySuccessfulValidations(t *testing.T, vali *validator.Validate, validObjects []interface{}) {

--- a/com/statuszusatzinformation_test.go
+++ b/com/statuszusatzinformation_test.go
@@ -65,6 +65,6 @@ func Test_StatusZusatzInformation_FailedValidation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
-func (s *Suite) Test_Serialized_Empty_StatusZusatzInformation_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.StatusZusatzInformation{})
+func Test_Serialized_Empty_StatusZusatzInformation_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.StatusZusatzInformation{})
 }

--- a/com/statuszusatzinformation_test.go
+++ b/com/statuszusatzinformation_test.go
@@ -2,17 +2,19 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/status"
 	"github.com/hochfrequenz/go-bo4e/enum/statusart"
-	"strings"
 )
 
 // Test_StatusZusatzInformation_Deserialization deserializes an StatusZusatzInformation json
-func (s *Suite) Test_StatusZusatzInformation_Deserialization() {
+func Test_StatusZusatzInformation_Deserialization(t *testing.T) {
 	gasQualitaetArt := statusart.GASQUALITAET
 	var sts = com.StatusZusatzInformation{
 		Art:    &gasQualitaetArt,
@@ -21,19 +23,19 @@ func (s *Suite) Test_StatusZusatzInformation_Deserialization() {
 
 	serializedSts, err := json.Marshal(sts)
 	jsonString := string(serializedSts)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "GASQUALITAET"), is.True())
-	then.AssertThat(s.T(), strings.Contains(jsonString, "BRENNWERTKORREKTUR"), is.True())
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedSts, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "GASQUALITAET"), is.True())
+	then.AssertThat(t, strings.Contains(jsonString, "BRENNWERTKORREKTUR"), is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedSts, is.Not(is.NilArray[byte]()))
 	var deserializedSts com.StatusZusatzInformation
 	err = json.Unmarshal(serializedSts, &deserializedSts)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedSts, is.EqualTo(sts))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedSts, is.EqualTo(sts))
 }
 
 // Test_Successful_StatusZusatzInformation_Validation asserts that the validation
 // does not fail for a valid StatusZusatzInformation
-func (s *Suite) Test_Successful_StatusZusatzInformation_Validation() {
+func Test_Successful_StatusZusatzInformation_Validation(t *testing.T) {
 	statusartGasqualitaet := statusart.GASQUALITAET
 	validate := validator.New()
 	validSts := []interface{}{
@@ -45,12 +47,12 @@ func (s *Suite) Test_Successful_StatusZusatzInformation_Validation() {
 			Status: status.BRENNWERTKORREKTUR,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validSts)
+	VerifySuccessfulValidations(t, validate, validSts)
 }
 
 // Test_StatusZusatzInformation_FailedValidation verifies that invalid
 // StatusZusatzInformation values are considered invalid
-func (s *Suite) Test_StatusZusatzInformation_FailedValidation() {
+func Test_StatusZusatzInformation_FailedValidation(t *testing.T) {
 	statusartGasqualitaet := statusart.GASQUALITAET
 	validate := validator.New()
 	invalidVerbrauchMap := map[string][]interface{}{
@@ -60,7 +62,7 @@ func (s *Suite) Test_StatusZusatzInformation_FailedValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVerbrauchMap)
+	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
 func (s *Suite) Test_Serialized_Empty_StatusZusatzInformation_Contains_No_Enum_Defaults() {

--- a/com/steuerbetrag_test.go
+++ b/com/steuerbetrag_test.go
@@ -66,6 +66,6 @@ func Test_Successful_SteuerbetragValidation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validSteuerbetraege)
 }
 
-func (s *Suite) Test_Serialized_Empty_Steuerbetrag_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Steuerbetrag{})
+func Test_Serialized_Empty_Steuerbetrag_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Steuerbetrag{})
 }

--- a/com/steuerbetrag_test.go
+++ b/com/steuerbetrag_test.go
@@ -1,6 +1,8 @@
 package com_test
 
 import (
+	"testing"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/steuerkennzeichen"
@@ -9,7 +11,7 @@ import (
 )
 
 // TestFailedSteuerbetragValidation asserts that the validation fails for invalid Steuerbetrag
-func (s *Suite) Test_Failed_SteuerbetragValidation() {
+func Test_Failed_SteuerbetragValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.SteuerbetragStructLevelValidation, com.Steuerbetrag{})
 	invalidSteuerbetrag := map[string][]interface{}{
@@ -30,11 +32,11 @@ func (s *Suite) Test_Failed_SteuerbetragValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidSteuerbetrag)
+	VerifyFailedValidations(t, validate, invalidSteuerbetrag)
 }
 
 // TestSuccessfulSteuerbetragValidation asserts that the validation does not fail for a valid Steuerbetrag
-func (s *Suite) Test_Successful_SteuerbetragValidation() {
+func Test_Successful_SteuerbetragValidation(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(com.SteuerbetragStructLevelValidation, com.Steuerbetrag{})
 	validSteuerbetraege := []interface{}{
@@ -61,7 +63,7 @@ func (s *Suite) Test_Successful_SteuerbetragValidation() {
 			Waehrung:          waehrungscode.EUR,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validSteuerbetraege)
+	VerifySuccessfulValidations(t, validate, validSteuerbetraege)
 }
 
 func (s *Suite) Test_Serialized_Empty_Steuerbetrag_Contains_No_Enum_Defaults() {

--- a/com/tagesparameter_test.go
+++ b/com/tagesparameter_test.go
@@ -1,12 +1,14 @@
 package com_test
 
 import (
+	"testing"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 )
 
 // Test_Failed_Tagesparameter_Validation asserts that the validation fails for invalid Tagesparameter
-func (s *Suite) Test_Failed_Tagesparameter_Validation() {
+func Test_Failed_Tagesparameter_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidTagesparameters := map[string][]interface{}{
 		"required_with": {
@@ -27,11 +29,11 @@ func (s *Suite) Test_Failed_Tagesparameter_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidTagesparameters)
+	VerifyFailedValidations(t, validate, invalidTagesparameters)
 }
 
 // Test_Successful_Tagesparameter_Validation asserts that the validation does not fail for a valid Tagesparameter
-func (s *Suite) Test_Successful_Tagesparameter_Validation() {
+func Test_Successful_Tagesparameter_Validation(t *testing.T) {
 	validate := validator.New()
 	validTagesparameter := []interface{}{
 		com.Tagesparameter{}, // by default nothing is required
@@ -41,5 +43,5 @@ func (s *Suite) Test_Successful_Tagesparameter_Validation() {
 			Dienstanbieter:       "bar",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validTagesparameter)
+	VerifySuccessfulValidations(t, validate, validTagesparameter)
 }

--- a/com/unterschrift_test.go
+++ b/com/unterschrift_test.go
@@ -2,16 +2,18 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
-	"strings"
-	"time"
 )
 
 // TestUnterschriftDeserialization deserializes an Unterschrift json
-func (s *Suite) Test_Unterschrift_Deserialization() {
+func Test_Unterschrift_Deserialization(t *testing.T) {
 	var unterschrift = com.Unterschrift{
 		Name:  "Max Mustermann",
 		Datum: time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),
@@ -20,18 +22,18 @@ func (s *Suite) Test_Unterschrift_Deserialization() {
 
 	serializedUnterschrift, err := json.Marshal(unterschrift)
 	jsonString := string(serializedUnterschrift)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "Max Mustermann"), is.True())           // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "\"2021-08-01T00:00:00Z\""), is.True()) // ISO8601 ftw
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedUnterschrift, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "Max Mustermann"), is.True())           // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "\"2021-08-01T00:00:00Z\""), is.True()) // ISO8601 ftw
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedUnterschrift, is.Not(is.NilArray[byte]()))
 	var deserializedUnterschrift com.Unterschrift
 	err = json.Unmarshal(serializedUnterschrift, &deserializedUnterschrift)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedUnterschrift, is.EqualTo(unterschrift))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedUnterschrift, is.EqualTo(unterschrift))
 }
 
 // Test_Successful_Unterschrift_Validation asserts that the validation does not fail for a valid Unterschrift
-func (s *Suite) Test_Successful_Unterschrift_Validation() {
+func Test_Successful_Unterschrift_Validation(t *testing.T) {
 	validate := validator.New()
 	validUnterschrift := []interface{}{
 		com.Unterschrift{
@@ -43,11 +45,11 @@ func (s *Suite) Test_Successful_Unterschrift_Validation() {
 			Name: "Max Mustermann",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validUnterschrift)
+	VerifySuccessfulValidations(t, validate, validUnterschrift)
 }
 
 // TestUnterschriftFailedValidation verifies that invalid Unterschrift values are considered invalid
-func (s *Suite) Test_Unterschrift_FailedValidation() {
+func Test_Unterschrift_FailedValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVerbrauchMap := map[string][]interface{}{
 		"required": {
@@ -58,7 +60,7 @@ func (s *Suite) Test_Unterschrift_FailedValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVerbrauchMap)
+	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
 func (s *Suite) Test_Serialized_Empty_Unterschrift_Contains_No_Enum_Defaults() {

--- a/com/unterschrift_test.go
+++ b/com/unterschrift_test.go
@@ -63,6 +63,6 @@ func Test_Unterschrift_FailedValidation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
-func (s *Suite) Test_Serialized_Empty_Unterschrift_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Unterschrift{})
+func Test_Serialized_Empty_Unterschrift_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Unterschrift{})
 }

--- a/com/verbrauch_test.go
+++ b/com/verbrauch_test.go
@@ -89,6 +89,6 @@ func Test_Verbrauch_FailedValidation(t *testing.T) {
 	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
-func (s *Suite) Test_Serialized_Empty_Verbrauch_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Verbrauch{})
+func Test_Serialized_Empty_Verbrauch_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Verbrauch{})
 }

--- a/com/verbrauch_test.go
+++ b/com/verbrauch_test.go
@@ -3,6 +3,7 @@ package com_test
 import (
 	"encoding/json"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/corbym/gocrest/is"
@@ -17,7 +18,7 @@ import (
 )
 
 // Test_Deserialization deserializes an Verbrauch json
-func (s *Suite) Test_Verbrauch_Deserialization() {
+func Test_Verbrauch_Deserialization(t *testing.T) {
 	var verbrauch = com.Verbrauch{
 		Startdatum:               time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),
 		Enddatum:                 time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC).Add(time.Minute * 15),
@@ -31,19 +32,19 @@ func (s *Suite) Test_Verbrauch_Deserialization() {
 	}
 	serializedVerbrauch, err := json.Marshal(verbrauch)
 	jsonString := string(serializedVerbrauch)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "KWH"), is.True())                      // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "\"2021-08-01T00:00:00Z\""), is.True()) // ISO8601 ftw
-	then.AssertThat(s.T(), strings.Contains(jsonString, "\"2023-01-01T00:00:00Z\""), is.True()) // ISO8601 ftw
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedVerbrauch, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "KWH"), is.True())                      // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "\"2021-08-01T00:00:00Z\""), is.True()) // ISO8601 ftw
+	then.AssertThat(t, strings.Contains(jsonString, "\"2023-01-01T00:00:00Z\""), is.True()) // ISO8601 ftw
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedVerbrauch, is.Not(is.NilArray[byte]()))
 	var deserializedVerbrauch com.Verbrauch
 	err = json.Unmarshal(serializedVerbrauch, &deserializedVerbrauch)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedVerbrauch, is.EqualTo(verbrauch))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedVerbrauch, is.EqualTo(verbrauch))
 }
 
 // Test_Successful_Verbrauch_Validation asserts that the validation does not fail for a valid Verbrauch
-func (s *Suite) Test_Successful_Verbrauch_Validation() {
+func Test_Successful_Verbrauch_Validation(t *testing.T) {
 	validate := validator.New()
 	validVerbrauch := []interface{}{
 		com.Verbrauch{
@@ -57,11 +58,11 @@ func (s *Suite) Test_Successful_Verbrauch_Validation() {
 			Ausfuehrungszeitpunkt:    time.Now(),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validVerbrauch)
+	VerifySuccessfulValidations(t, validate, validVerbrauch)
 }
 
 // TestVerbrauchFailedValidation verifies that invalid verbrauch values are considered invalid
-func (s *Suite) Test_Verbrauch_FailedValidation() {
+func Test_Verbrauch_FailedValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVerbrauchMap := map[string][]interface{}{
 		"required": {
@@ -85,7 +86,7 @@ func (s *Suite) Test_Verbrauch_FailedValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVerbrauchMap)
+	VerifyFailedValidations(t, validate, invalidVerbrauchMap)
 }
 
 func (s *Suite) Test_Serialized_Empty_Verbrauch_Contains_No_Enum_Defaults() {

--- a/com/vertragskonditionen_test.go
+++ b/com/vertragskonditionen_test.go
@@ -78,6 +78,6 @@ func Test_Successful_Vertragkonditionen_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validVertragskonditionens)
 }
 
-func (s *Suite) Test_Serialized_Empty_Vertragskonditionen_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Vertragskonditionen{})
+func Test_Serialized_Empty_Vertragskonditionen_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Vertragskonditionen{})
 }

--- a/com/vertragskonditionen_test.go
+++ b/com/vertragskonditionen_test.go
@@ -2,6 +2,10 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,8 +13,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/zeiteinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"strings"
-	"time"
 )
 
 var validVertragskonditionen = com.Vertragskonditionen{
@@ -39,20 +41,20 @@ var validVertragskonditionen = com.Vertragskonditionen{
 }
 
 // TestVertragskonditionenDeserialization deserializes a Vertragskonditionen json
-func (s *Suite) Test_Vertragskonditionen_Deserialization() {
+func Test_Vertragskonditionen_Deserialization(t *testing.T) {
 	serializedVertragskonditionen, err := json.Marshal(validVertragskonditionen)
 	jsonString := string(serializedVertragskonditionen)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "MINUTE"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedVertragskonditionen, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "MINUTE"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedVertragskonditionen, is.Not(is.NilArray[byte]()))
 	var deserializedVertragskonditionen com.Vertragskonditionen
 	err = json.Unmarshal(serializedVertragskonditionen, &deserializedVertragskonditionen)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedVertragskonditionen, is.EqualTo(validVertragskonditionen))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedVertragskonditionen, is.EqualTo(validVertragskonditionen))
 }
 
 // Test_Vertragskonditionen_Failed_Validation verifies that the validation fails for invalid Vertragskonditionen s
-func (s *Suite) Test_Vertragskonditionen_Failed_Validation() {
+func Test_Vertragskonditionen_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidZeitraums := map[string][]interface{}{
 		"required_with": {
@@ -64,16 +66,16 @@ func (s *Suite) Test_Vertragskonditionen_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidZeitraums)
+	VerifyFailedValidations(t, validate, invalidZeitraums)
 }
 
 // Test_Successful_Vertragskonditionen_Validation asserts that the validation does not fail for a valid Vertragskonditionen
-func (s *Suite) Test_Successful_Vertragkonditionen_Validation() {
+func Test_Successful_Vertragkonditionen_Validation(t *testing.T) {
 	validate := validator.New()
 	validVertragskonditionens := []interface{}{
 		validVertragskonditionen,
 	}
-	VerfiySuccessfulValidations(s, validate, validVertragskonditionens)
+	VerifySuccessfulValidations(t, validate, validVertragskonditionens)
 }
 
 func (s *Suite) Test_Serialized_Empty_Vertragskonditionen_Contains_No_Enum_Defaults() {

--- a/com/vertragsteil_test.go
+++ b/com/vertragsteil_test.go
@@ -124,6 +124,6 @@ func Test_Successful_Vertragsteil_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validVertragsteile)
 }
 
-func (s *Suite) Test_Serialized_Empty_Vertragsteil_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Vertragsteil{})
+func Test_Serialized_Empty_Vertragsteil_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Vertragsteil{})
 }

--- a/com/vertragsteil_test.go
+++ b/com/vertragsteil_test.go
@@ -2,6 +2,10 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,12 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"strings"
-	"time"
 )
 
 // TestVertragsteilDeserialization deserializes a Vertragsteil json
-func (s *Suite) Test_Vertragsteil_Deserialization() {
+func Test_Vertragsteil_Deserialization(t *testing.T) {
 	var vertraqsteil = com.Vertragsteil{
 		Vertragsteilbeginn: time.Date(2022, 8, 1, 0, 0, 0, 0, time.UTC),
 		Vertragsteilende:   time.Date(2023, 8, 1, 0, 0, 0, 0, time.UTC),
@@ -34,17 +36,17 @@ func (s *Suite) Test_Vertragsteil_Deserialization() {
 	}
 	serializedVertragsteil, err := json.Marshal(vertraqsteil)
 	jsonString := string(serializedVertragsteil)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "KUBIKMETER"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedVertragsteil, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "KUBIKMETER"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedVertragsteil, is.Not(is.NilArray[byte]()))
 	var deserializedVertragsteil com.Vertragsteil
 	err = json.Unmarshal(serializedVertragsteil, &deserializedVertragsteil)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedVertragsteil, is.EqualTo(vertraqsteil))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedVertragsteil, is.EqualTo(vertraqsteil))
 }
 
 // Test_Vertragsteil_Failed_Validation verifies that the validation fails for invalid Vertragsteil
-func (s *Suite) Test_Vertragsteil_Failed_Validation() {
+func Test_Vertragsteil_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidVertragsteile := map[string][]interface{}{
 		"required": {
@@ -85,11 +87,11 @@ func (s *Suite) Test_Vertragsteil_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVertragsteile)
+	VerifyFailedValidations(t, validate, invalidVertragsteile)
 }
 
 // Test_Successful_Vertragskonditionen_Validation asserts that the validation does not fail for a valid Vertragskonditionen
-func (s *Suite) Test_Successful_Vertragsteil_Validation() {
+func Test_Successful_Vertragsteil_Validation(t *testing.T) {
 	validate := validator.New()
 	validVertragsteile := []interface{}{
 		com.Vertragsteil{
@@ -119,7 +121,7 @@ func (s *Suite) Test_Successful_Vertragsteil_Validation() {
 			Lokation:           "543231012345",
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validVertragsteile)
+	VerifySuccessfulValidations(t, validate, validVertragsteile)
 }
 
 func (s *Suite) Test_Serialized_Empty_Vertragsteil_Contains_No_Enum_Defaults() {

--- a/com/vorauszahlung_test.go
+++ b/com/vorauszahlung_test.go
@@ -45,6 +45,6 @@ func Test_Successful_VorauszahlungValidation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validBetraege)
 }
 
-func (s *Suite) Test_Serialized_Empty_Vorauszahlung_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Vorauszahlung{})
+func Test_Serialized_Empty_Vorauszahlung_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Vorauszahlung{})
 }

--- a/com/vorauszahlung_test.go
+++ b/com/vorauszahlung_test.go
@@ -1,14 +1,16 @@
 package com_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungscode"
 	"github.com/shopspring/decimal"
-	"time"
 )
 
-func (s *Suite) Test_Failed_VorauszahlungValidation() {
+func Test_Failed_VorauszahlungValidation(t *testing.T) {
 	validate := validator.New()
 	invalidVorauszahlungMap := map[string][]interface{}{
 		"required": {
@@ -17,10 +19,10 @@ func (s *Suite) Test_Failed_VorauszahlungValidation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVorauszahlungMap)
+	VerifyFailedValidations(t, validate, invalidVorauszahlungMap)
 }
 
-func (s *Suite) Test_Successful_VorauszahlungValidation() {
+func Test_Successful_VorauszahlungValidation(t *testing.T) {
 	validate := validator.New()
 	arbitraryReferenz := "foo"
 	arbitraryDate := time.Date(2022, 9, 1, 0, 0, 0, 0, time.UTC)
@@ -40,7 +42,7 @@ func (s *Suite) Test_Successful_VorauszahlungValidation() {
 			ReferenzDatum: &arbitraryDate,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validBetraege)
+	VerifySuccessfulValidations(t, validate, validBetraege)
 }
 
 func (s *Suite) Test_Serialized_Empty_Vorauszahlung_Contains_No_Enum_Defaults() {

--- a/com/zaehlerstaende_test.go
+++ b/com/zaehlerstaende_test.go
@@ -1,31 +1,33 @@
 package com_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
 	"github.com/shopspring/decimal"
-	"time"
 )
 
 // TestZaehlerstaneLen tests the Zaehlerstaende.Len function
-func (s *Suite) Test_Zaehlerstande_Len() {
+func Test_Zaehlerstande_Len(t *testing.T) {
 	zaehlerstaende3 := com.Zaehlerstaende{
 		com.Zaehlerstand{},
 		com.Zaehlerstand{},
 		com.Zaehlerstand{},
 	}
 	zaehlerstaende0 := com.Zaehlerstaende{}
-	then.AssertThat(s.T(), zaehlerstaende3.Len(), is.EqualTo(3))
-	then.AssertThat(s.T(), zaehlerstaende0.Len(), is.EqualTo(0))
+	then.AssertThat(t, zaehlerstaende3.Len(), is.EqualTo(3))
+	then.AssertThat(t, zaehlerstaende0.Len(), is.EqualTo(0))
 	zaehlerstaende0 = nil
-	then.AssertThat(s.T(), zaehlerstaende0.Len(), is.EqualTo(0))
+	then.AssertThat(t, zaehlerstaende0.Len(), is.EqualTo(0))
 }
 
 // Test_Zaehlerstande_Swap tests the Zaehlerstaende.Swap function
-func (s *Suite) Test_Zaehlerstande_Swap() {
+func Test_Zaehlerstande_Swap(t *testing.T) {
 	zaehlerstaende := com.Zaehlerstaende{
 		com.Zaehlerstand{
 			Ablesedatum:              time.Time{},
@@ -46,15 +48,15 @@ func (s *Suite) Test_Zaehlerstande_Swap() {
 			Einheit:                  mengeneinheit.KW,
 		},
 	}
-	then.AssertThat(s.T(), zaehlerstaende[1].Wert, is.EqualTo(decimal.NewFromFloat(42.1)))
-	then.AssertThat(s.T(), zaehlerstaende[2].Wert, is.EqualTo(decimal.NewFromFloat(123.2)))
+	then.AssertThat(t, zaehlerstaende[1].Wert, is.EqualTo(decimal.NewFromFloat(42.1)))
+	then.AssertThat(t, zaehlerstaende[2].Wert, is.EqualTo(decimal.NewFromFloat(123.2)))
 	zaehlerstaende.Swap(1, 2)
-	then.AssertThat(s.T(), zaehlerstaende[1].Wert, is.EqualTo(decimal.NewFromFloat(123.2)))
-	then.AssertThat(s.T(), zaehlerstaende[2].Wert, is.EqualTo(decimal.NewFromFloat(42.1)))
+	then.AssertThat(t, zaehlerstaende[1].Wert, is.EqualTo(decimal.NewFromFloat(123.2)))
+	then.AssertThat(t, zaehlerstaende[2].Wert, is.EqualTo(decimal.NewFromFloat(42.1)))
 }
 
 // Test_Zaehlerstaende_Less tests the Zaehlerstaende.Less function
-func (s *Suite) Test_Zaehlerstaende_Less() {
+func Test_Zaehlerstaende_Less(t *testing.T) {
 	zaehlerstaende := com.Zaehlerstaende{
 		com.Zaehlerstand{
 			Ablesedatum:              time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC),
@@ -87,10 +89,10 @@ func (s *Suite) Test_Zaehlerstaende_Less() {
 			Einheit:                  mengeneinheit.KW,
 		},
 	}
-	then.AssertThat(s.T(), zaehlerstaende.Less(1, 2), is.True())
-	then.AssertThat(s.T(), zaehlerstaende.Less(2, 1), is.False())
-	then.AssertThat(s.T(), zaehlerstaende.Less(3, 0), is.False())
-	then.AssertThat(s.T(), zaehlerstaende.Less(0, 3), is.False())
-	then.AssertThat(s.T(), zaehlerstaende.Less(0, 4), is.True())
-	then.AssertThat(s.T(), zaehlerstaende.Less(4, 0), is.False())
+	then.AssertThat(t, zaehlerstaende.Less(1, 2), is.True())
+	then.AssertThat(t, zaehlerstaende.Less(2, 1), is.False())
+	then.AssertThat(t, zaehlerstaende.Less(3, 0), is.False())
+	then.AssertThat(t, zaehlerstaende.Less(0, 3), is.False())
+	then.AssertThat(t, zaehlerstaende.Less(0, 4), is.True())
+	then.AssertThat(t, zaehlerstaende.Less(4, 0), is.False())
 }

--- a/com/zaehlerstand_test.go
+++ b/com/zaehlerstand_test.go
@@ -64,6 +64,6 @@ func Test_Successful_Zaehlerstand_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validZaehlerstaende)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zaehlerstand_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zaehlerstand{})
+func Test_Serialized_Empty_Zaehlerstand_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zaehlerstand{})
 }

--- a/com/zaehlerstand_test.go
+++ b/com/zaehlerstand_test.go
@@ -2,6 +2,10 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,12 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
 	"github.com/shopspring/decimal"
-	"strings"
-	"time"
 )
 
 // TestZaehlerstandDeserialization deserializes a Zaehlerstand json
-func (s *Suite) Test_Zaehlerstand_Deserialization() {
+func Test_Zaehlerstand_Deserialization(t *testing.T) {
 	var zaehlerstand = com.Zaehlerstand{
 		Ablesedatum:              time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),
 		Wertermittlungsverfahren: wertermittlungsverfahren.MESSUNG,
@@ -24,19 +26,19 @@ func (s *Suite) Test_Zaehlerstand_Deserialization() {
 	}
 	serializedZaehlerstand, err := json.Marshal(zaehlerstand)
 	jsonString := string(serializedZaehlerstand)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "MESSUNG"), is.True())      // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "KWH"), is.True())          // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "zustandszahl"), is.True()) // is not omitted
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZaehlerstand, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "MESSUNG"), is.True())      // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "KWH"), is.True())          // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "zustandszahl"), is.True()) // is not omitted
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZaehlerstand, is.Not(is.NilArray[byte]()))
 	var deserializedZaehlerstand com.Zaehlerstand
 	err = json.Unmarshal(serializedZaehlerstand, &deserializedZaehlerstand)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZaehlerstand, is.EqualTo(zaehlerstand))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZaehlerstand, is.EqualTo(zaehlerstand))
 }
 
 // Test_Zaehlerstand_Failed_Validation verifies that the validation fails for invalid Zaehlerstand s
-func (s *Suite) Test_Zaehlerstand_Failed_Validation() {
+func Test_Zaehlerstand_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidZaehlerstand := map[string][]interface{}{
 		"required": {
@@ -45,11 +47,11 @@ func (s *Suite) Test_Zaehlerstand_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidZaehlerstand)
+	VerifyFailedValidations(t, validate, invalidZaehlerstand)
 }
 
 // Test_Successful_Zaehlerstand_Validation asserts that the validation does not fail for a valid Zaehlerstand
-func (s *Suite) Test_Successful_Zaehlerstand_Validation() {
+func Test_Successful_Zaehlerstand_Validation(t *testing.T) {
 	validate := validator.New()
 	validZaehlerstaende := []interface{}{
 		com.Zaehlerstand{
@@ -59,7 +61,7 @@ func (s *Suite) Test_Successful_Zaehlerstand_Validation() {
 			Einheit:                  mengeneinheit.KWH,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validZaehlerstaende)
+	VerifySuccessfulValidations(t, validate, validZaehlerstaende)
 }
 
 func (s *Suite) Test_Serialized_Empty_Zaehlerstand_Contains_No_Enum_Defaults() {

--- a/com/zaehlwerk_test.go
+++ b/com/zaehlwerk_test.go
@@ -2,6 +2,9 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,7 +12,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/energierichtung"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/shopspring/decimal"
-	"strings"
 )
 
 // TestZaehlwerkDeserialization deserializes a Zaehlwerk json
@@ -89,6 +91,6 @@ func (s *Suite) Test_Successful_Zaehlwerk_Validation() {
 	VerfiySuccessfulValidations(s, validate, validZaehlwerke)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zaehlwerk_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zaehlwerk{})
+func Test_Serialized_Empty_Zaehlwerk_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zaehlwerk{})
 }

--- a/com/zaehlwerk_test.go
+++ b/com/zaehlwerk_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 // TestZaehlwerkDeserialization deserializes a Zaehlwerk json
-func (s *Suite) Test_Zaehlwerk_Deserialization() {
+func Test_Zaehlwerk_Deserialization(t *testing.T) {
 	// Warning: This test makes use of global variables of a package (3rd-party). It must not be parallelized!
 
 	decimal.MarshalJSONWithoutQuotes = true
@@ -31,21 +31,21 @@ func (s *Suite) Test_Zaehlwerk_Deserialization() {
 	}
 	serializedZaehlwerk, err := json.Marshal(zaehlwerk)
 	jsonString := string(serializedZaehlwerk)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "KWH"), is.True())                 // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "AUSSP"), is.True())               // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "wandlerfaktor\":1.2"), is.True()) // no quotes around the decimal
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZaehlwerk, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "KWH"), is.True())                 // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "AUSSP"), is.True())               // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "wandlerfaktor\":1.2"), is.True()) // no quotes around the decimal
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZaehlwerk, is.Not(is.NilArray[byte]()))
 	var deserializedZaehlwerk com.Zaehlwerk
 	err = json.Unmarshal(serializedZaehlwerk, &deserializedZaehlwerk)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZaehlwerk.ExtensionData.CompareTo(zaehlwerk.ExtensionData), is.True())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZaehlwerk.ExtensionData.CompareTo(zaehlwerk.ExtensionData), is.True())
 	zaehlwerk.ExtensionData = deserializedZaehlwerk.ExtensionData
-	then.AssertThat(s.T(), deserializedZaehlwerk, is.EqualTo(zaehlwerk))
+	then.AssertThat(t, deserializedZaehlwerk, is.EqualTo(zaehlwerk))
 }
 
 // Test_Zaehlwerk_Decimal_As_Number_Serialization serializes a Zaehlwerk, once with the wandlerfaktor as string (default), once as number
-func (s *Suite) Test_Zaehlwerk_Decimal_As_Number_Serialization() {
+func Test_Zaehlwerk_Decimal_As_Number_Serialization(t *testing.T) {
 	// Warning: This test makes use of global variables of a package (3rd-party). It must not be parallelized!
 
 	var zaehlwerk = com.Zaehlwerk{
@@ -54,19 +54,19 @@ func (s *Suite) Test_Zaehlwerk_Decimal_As_Number_Serialization() {
 
 	decimal.MarshalJSONWithoutQuotes = false
 	serializedZaehlwerk, err := json.Marshal(zaehlwerk)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	jsonString := string(serializedZaehlwerk)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "wandlerfaktor\":\"1.2\""), is.True()) // decimal as string by default: https://github.com/shopspring/decimal/issues/21
+	then.AssertThat(t, strings.Contains(jsonString, "wandlerfaktor\":\"1.2\""), is.True()) // decimal as string by default: https://github.com/shopspring/decimal/issues/21
 
 	decimal.MarshalJSONWithoutQuotes = true // https://github.com/shopspring/decimal/blob/fa3b22f4d484d626ee81919285cf3d22ad3a4000/decimal.go#L47
 	serializedZaehlwerk, err = json.Marshal(zaehlwerk)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 	jsonString = string(serializedZaehlwerk)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "wandlerfaktor\":1.2"), is.True()) // decimal as number
+	then.AssertThat(t, strings.Contains(jsonString, "wandlerfaktor\":1.2"), is.True()) // decimal as number
 }
 
 // Test_Zaehlwerk_Failed_Validation verifies that the validation fails for invalid Zaehlwerk
-func (s *Suite) Test_Zaehlwerk_Failed_Validation() {
+func Test_Zaehlwerk_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidVertragsteile := map[string][]interface{}{
 		"required": {
@@ -78,11 +78,11 @@ func (s *Suite) Test_Zaehlwerk_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidVertragsteile)
+	VerifyFailedValidations(t, validate, invalidVertragsteile)
 }
 
 // Test_Successful_Zaehlwerk_Validation asserts that the validation does not fail for a valid Zaehlwerk
-func (s *Suite) Test_Successful_Zaehlwerk_Validation() {
+func Test_Successful_Zaehlwerk_Validation(t *testing.T) {
 	validate := validator.New()
 	validZaehlwerke := []interface{}{
 		com.Zaehlwerk{
@@ -95,7 +95,7 @@ func (s *Suite) Test_Successful_Zaehlwerk_Validation() {
 			Zaehlerstaende: nil,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validZaehlwerke)
+	VerifySuccessfulValidations(t, validate, validZaehlwerke)
 }
 
 func Test_Serialized_Empty_Zaehlwerk_Contains_No_Enum_Defaults(t *testing.T) {

--- a/com/zaehlwerk_test.go
+++ b/com/zaehlwerk_test.go
@@ -16,6 +16,10 @@ import (
 
 // TestZaehlwerkDeserialization deserializes a Zaehlwerk json
 func (s *Suite) Test_Zaehlwerk_Deserialization() {
+	// Warning: This test makes use of global variables of a package (3rd-party). It must not be parallelized!
+
+	decimal.MarshalJSONWithoutQuotes = true
+
 	var zaehlwerk = com.Zaehlwerk{
 		ZaehlwerkId:    "1",
 		Bezeichnung:    "bestes Zählwerk",
@@ -42,16 +46,19 @@ func (s *Suite) Test_Zaehlwerk_Deserialization() {
 
 // Test_Zaehlwerk_Decimal_As_Number_Serialization serializes a Zaehlwerk, once with the wandlerfaktor as string (default), once as number
 func (s *Suite) Test_Zaehlwerk_Decimal_As_Number_Serialization() {
+	// Warning: This test makes use of global variables of a package (3rd-party). It must not be parallelized!
+
 	var zaehlwerk = com.Zaehlwerk{
 		Wandlerfaktor: decimal.NewFromFloat(1.2),
 	}
+
+	decimal.MarshalJSONWithoutQuotes = false
 	serializedZaehlwerk, err := json.Marshal(zaehlwerk)
 	then.AssertThat(s.T(), err, is.Nil())
 	jsonString := string(serializedZaehlwerk)
 	then.AssertThat(s.T(), strings.Contains(jsonString, "wandlerfaktor\":\"1.2\""), is.True()) // decimal as string by default: https://github.com/shopspring/decimal/issues/21
 
 	decimal.MarshalJSONWithoutQuotes = true // https://github.com/shopspring/decimal/blob/fa3b22f4d484d626ee81919285cf3d22ad3a4000/decimal.go#L47
-
 	serializedZaehlwerk, err = json.Marshal(zaehlwerk)
 	then.AssertThat(s.T(), err, is.Nil())
 	jsonString = string(serializedZaehlwerk)

--- a/com/zaehlzeit_test.go
+++ b/com/zaehlzeit_test.go
@@ -49,6 +49,6 @@ func Test_Successful_Zaehlzeit_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validAbweichung)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zaehlzeit_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zaehlzeit{})
+func Test_Serialized_Empty_Zaehlzeit_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zaehlzeit{})
 }

--- a/com/zaehlzeit_test.go
+++ b/com/zaehlzeit_test.go
@@ -2,6 +2,8 @@ package com_test
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -11,7 +13,7 @@ import (
 const foo = "foo"
 const bar = "bar"
 
-func (s *Suite) Test_Zaehlzeit_Deserialization() {
+func Test_Zaehlzeit_Deserialization(t *testing.T) {
 	_foo := foo
 	_bar := bar
 	zaehlzeit := com.Zaehlzeit{
@@ -19,15 +21,15 @@ func (s *Suite) Test_Zaehlzeit_Deserialization() {
 		Zaehlzeitregister:   &_bar,
 	}
 	serializedZaehlzeit, err := json.Marshal(zaehlzeit)
-	then.AssertThat(s.T(), serializedZaehlzeit, is.Not(is.NilArray[byte]()))
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, serializedZaehlzeit, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
 	deserializedZaehlzeit := com.Zaehlzeit{}
 	err = json.Unmarshal(serializedZaehlzeit, &deserializedZaehlzeit)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZaehlzeit, is.EqualTo(zaehlzeit))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZaehlzeit, is.EqualTo(zaehlzeit))
 }
 
-func (s *Suite) Test_Successful_Zaehlzeit_Validation() {
+func Test_Successful_Zaehlzeit_Validation(t *testing.T) {
 	validate := validator.New()
 	_foo := foo
 	_bar := bar
@@ -44,7 +46,7 @@ func (s *Suite) Test_Successful_Zaehlzeit_Validation() {
 		},
 		com.Zaehlzeit{},
 	}
-	VerfiySuccessfulValidations(s, validate, validAbweichung)
+	VerifySuccessfulValidations(t, validate, validAbweichung)
 }
 
 func (s *Suite) Test_Serialized_Empty_Zaehlzeit_Contains_No_Enum_Defaults() {

--- a/com/zeitraum_test.go
+++ b/com/zeitraum_test.go
@@ -2,6 +2,10 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,12 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/zeiteinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
-	"strings"
-	"time"
 )
 
 // TestZeitraumDeserialization deserializes a Zeitraum json
-func (s *Suite) Test_Zeitraum_Deserialization() {
+func Test_Zeitraum_Deserialization(t *testing.T) {
 	var zeitraum = com.Zeitraum{
 		Einheit:        zeiteinheit.MINUTE,
 		Dauer:          decimal.NewNullDecimal(decimal.NewFromFloat(15)),
@@ -25,34 +27,34 @@ func (s *Suite) Test_Zeitraum_Deserialization() {
 	}
 	serializedZeitraum, err := json.Marshal(zeitraum)
 	jsonString := string(serializedZeitraum)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "MINUTE"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZeitraum, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "MINUTE"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZeitraum, is.Not(is.NilArray[byte]()))
 	var deserializedZeitreihenwert com.Zeitraum
 	err = json.Unmarshal(serializedZeitraum, &deserializedZeitreihenwert)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZeitreihenwert, is.EqualTo(zeitraum))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZeitreihenwert, is.EqualTo(zeitraum))
 }
 
 // TestZeitraumDeserializationWithoutEinheit
-func (s *Suite) Test_Zeitraum_DeserializationWithoutEinheit() {
+func Test_Zeitraum_DeserializationWithoutEinheit(t *testing.T) {
 	var zeitraum = com.Zeitraum{
 		Startzeitpunkt: internal.Ptr(time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC)),
 		Endzeitpunkt:   internal.Ptr(time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC).Add(time.Minute * 15)),
 	}
 	serializedZeitraum, err := json.Marshal(zeitraum)
 	jsonString := string(serializedZeitraum)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "zeiteinheit"), is.False())
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZeitraum, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "zeiteinheit"), is.False())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZeitraum, is.Not(is.NilArray[byte]()))
 	var deserializedZeitreihenwert com.Zeitraum
 	err = json.Unmarshal(serializedZeitraum, &deserializedZeitreihenwert)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZeitreihenwert, is.EqualTo(zeitraum))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZeitreihenwert, is.EqualTo(zeitraum))
 }
 
 // Test_Zeitraum_Failed_Validation verifies that the validation fails for invalid Zeitraum s
-func (s *Suite) Test_Zeitraum_Failed_Validation() {
+func Test_Zeitraum_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidZeitraums := map[string][]interface{}{
 		"required_with": {
@@ -67,11 +69,11 @@ func (s *Suite) Test_Zeitraum_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidZeitraums)
+	VerifyFailedValidations(t, validate, invalidZeitraums)
 }
 
 // Test_Successful_Zeitreihenwert_Validation asserts that the validation does not fail for a valid Zeitreihenwert
-func (s *Suite) Test_Successful_Zeitraum_Validation() {
+func Test_Successful_Zeitraum_Validation(t *testing.T) {
 	validate := validator.New()
 	validZeitraums := []interface{}{
 		com.Zeitraum{
@@ -93,7 +95,7 @@ func (s *Suite) Test_Successful_Zeitraum_Validation() {
 			Enddatum:       internal.Ptr(time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC).Add(time.Minute * 15)),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validZeitraums)
+	VerifySuccessfulValidations(t, validate, validZeitraums)
 }
 
 func (s *Suite) Test_Serialized_Empty_Zeitraum_Contains_No_Enum_Defaults() {

--- a/com/zeitraum_test.go
+++ b/com/zeitraum_test.go
@@ -98,6 +98,6 @@ func Test_Successful_Zeitraum_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validZeitraums)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zeitraum_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zeitraum{})
+func Test_Serialized_Empty_Zeitraum_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zeitraum{})
 }

--- a/com/zeitreihenwert_test.go
+++ b/com/zeitreihenwert_test.go
@@ -2,6 +2,10 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,12 +13,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/messwertstatus"
 	"github.com/hochfrequenz/go-bo4e/enum/messwertstatuszusatz"
 	"github.com/shopspring/decimal"
-	"strings"
-	"time"
 )
 
 // TestZeitreihenwertDeserialization deserializes a Zeitreihenwert json
-func (s *Suite) Test_Zeitreihenwert_Deserialization() {
+func Test_Zeitreihenwert_Deserialization(t *testing.T) {
 	var zeitreihenwert = com.Zeitreihenwert{
 		Zeitreihenwertkompakt: com.Zeitreihenwertkompakt{
 			Wert:         decimal.NewFromFloat(17.43),
@@ -26,17 +28,17 @@ func (s *Suite) Test_Zeitreihenwert_Deserialization() {
 	}
 	serializedZeitreihenwert, err := json.Marshal(zeitreihenwert)
 	jsonString := string(serializedZeitreihenwert)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ENERGIEMENGESUMMIERT"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZeitreihenwert, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "ENERGIEMENGESUMMIERT"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZeitreihenwert, is.Not(is.NilArray[byte]()))
 	var deserializedZeitreihenwert com.Zeitreihenwert
 	err = json.Unmarshal(serializedZeitreihenwert, &deserializedZeitreihenwert)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZeitreihenwert, is.EqualTo(zeitreihenwert))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZeitreihenwert, is.EqualTo(zeitreihenwert))
 }
 
 // Test_Zeitreihenwert_Failed_Validation verifies that the validation fails for invalid Zeitreihenwert s
-func (s *Suite) Test_Zeitreihenwert_Failed_Validation() {
+func Test_Zeitreihenwert_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidZeitreihenwertkompakts := map[string][]interface{}{
 		"required": {
@@ -51,11 +53,11 @@ func (s *Suite) Test_Zeitreihenwert_Failed_Validation() {
 			},
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidZeitreihenwertkompakts)
+	VerifyFailedValidations(t, validate, invalidZeitreihenwertkompakts)
 }
 
 // Test_Successful_Zeitreihenwert_Validation asserts that the validation does not fail for a valid Zeitreihenwert
-func (s *Suite) Test_Successful_Zeitreihenwert_Validation() {
+func Test_Successful_Zeitreihenwert_Validation(t *testing.T) {
 	validate := validator.New()
 	validAddresses := []interface{}{
 		com.Zeitreihenwert{
@@ -68,7 +70,7 @@ func (s *Suite) Test_Successful_Zeitreihenwert_Validation() {
 			DatumUhrzeitBis: time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC).Add(time.Minute * 15),
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAddresses)
+	VerifySuccessfulValidations(t, validate, validAddresses)
 }
 
 func (s *Suite) Test_Serialized_Empty_Zeitreihenwert_Contains_No_Enum_Defaults() {

--- a/com/zeitreihenwert_test.go
+++ b/com/zeitreihenwert_test.go
@@ -73,6 +73,6 @@ func Test_Successful_Zeitreihenwert_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validAddresses)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zeitreihenwert_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zeitreihenwert{})
+func Test_Serialized_Empty_Zeitreihenwert_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zeitreihenwert{})
 }

--- a/com/zeitreihenwertkompakt_test.go
+++ b/com/zeitreihenwertkompakt_test.go
@@ -58,6 +58,6 @@ func Test_Successful_Zeitreihenwertkompakt_Validation(t *testing.T) {
 	VerifySuccessfulValidations(t, validate, validAddresses)
 }
 
-func (s *Suite) Test_Serialized_Empty_Zeitreihenwertkompakt_Contains_No_Enum_Defaults() {
-	s.assert_Does_Not_Serialize_Default_Enums(com.Zeitreihenwertkompakt{})
+func Test_Serialized_Empty_Zeitreihenwertkompakt_Contains_No_Enum_Defaults(t *testing.T) {
+	assertDoesNotSerializeDefaultEnums(t, com.Zeitreihenwertkompakt{})
 }

--- a/com/zeitreihenwertkompakt_test.go
+++ b/com/zeitreihenwertkompakt_test.go
@@ -2,6 +2,9 @@ package com_test
 
 import (
 	"encoding/json"
+	"strings"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/go-playground/validator/v10"
@@ -9,11 +12,10 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/messwertstatus"
 	"github.com/hochfrequenz/go-bo4e/enum/messwertstatuszusatz"
 	"github.com/shopspring/decimal"
-	"strings"
 )
 
 // Test_Deserialization deserializes a Zeitreihenwertkompakt json
-func (s *Suite) Test_Zeitreihenwertkompakt_Deserialization() {
+func Test_Zeitreihenwertkompakt_Deserialization(t *testing.T) {
 	var zeitreihenwertkompakt = com.Zeitreihenwertkompakt{
 		Wert:         decimal.NewFromFloat(17.32),
 		Status:       messwertstatus.ERSATZWERT,
@@ -21,18 +23,18 @@ func (s *Suite) Test_Zeitreihenwertkompakt_Deserialization() {
 	}
 	serializedZeitreihenwert, err := json.Marshal(zeitreihenwertkompakt)
 	jsonString := string(serializedZeitreihenwert)
-	then.AssertThat(s.T(), strings.Contains(jsonString, "ERSATZWERT"), is.True())           // stringified enum
-	then.AssertThat(s.T(), strings.Contains(jsonString, "Z77_SPANNUNGSAUSFALL"), is.True()) // stringified enum
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedZeitreihenwert, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, strings.Contains(jsonString, "ERSATZWERT"), is.True())           // stringified enum
+	then.AssertThat(t, strings.Contains(jsonString, "Z77_SPANNUNGSAUSFALL"), is.True()) // stringified enum
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedZeitreihenwert, is.Not(is.NilArray[byte]()))
 	var deserializedZeitreihenwert com.Zeitreihenwertkompakt
 	err = json.Unmarshal(serializedZeitreihenwert, &deserializedZeitreihenwert)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedZeitreihenwert, is.EqualTo(zeitreihenwertkompakt))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedZeitreihenwert, is.EqualTo(zeitreihenwertkompakt))
 }
 
 // Test_Zeitreihenwertkompakt_Failed_Validation verifies that the validation fails for invalid Zeitreihenwertkompakt s
-func (s *Suite) Test_Zeitreihenwertkompakt_Failed_Validation() {
+func Test_Zeitreihenwertkompakt_Failed_Validation(t *testing.T) {
 	validate := validator.New()
 	invalidZeitreihenwertkompakts := map[string][]interface{}{
 		"required": {
@@ -40,11 +42,11 @@ func (s *Suite) Test_Zeitreihenwertkompakt_Failed_Validation() {
 			// todo: find out how to validate empty decimals as required.
 		},
 	}
-	VerfiyFailedValidations(s, validate, invalidZeitreihenwertkompakts)
+	VerifyFailedValidations(t, validate, invalidZeitreihenwertkompakts)
 }
 
 // Test_Successful_Validation asserts that the validation does not fail for a valid Zeitreihenwertkompakt
-func (s *Suite) Test_Successful_Zeitreihenwertkompakt_Validation() {
+func Test_Successful_Zeitreihenwertkompakt_Validation(t *testing.T) {
 	validate := validator.New()
 	validAddresses := []interface{}{
 		com.Zeitreihenwertkompakt{
@@ -53,7 +55,7 @@ func (s *Suite) Test_Successful_Zeitreihenwertkompakt_Validation() {
 			Statuszusatz: 0,
 		},
 	}
-	VerfiySuccessfulValidations(s, validate, validAddresses)
+	VerifySuccessfulValidations(t, validate, validAddresses)
 }
 
 func (s *Suite) Test_Serialized_Empty_Zeitreihenwertkompakt_Contains_No_Enum_Defaults() {

--- a/enum/landescode/landescode_test.go
+++ b/enum/landescode/landescode_test.go
@@ -7,18 +7,9 @@ import (
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/enum/landescode"
-	"github.com/stretchr/testify/suite"
 )
 
-type Suite struct {
-	suite.Suite
-}
-
 // Test_Landescode_ToString deserializes an address json
-func (s *Suite) Test_Landescode_ToString() {
-	then.AssertThat(s.T(), fmt.Sprintf("%v", landescode.DE), is.EqualTo("DE"))
-}
-
-func TestInit(t *testing.T) {
-	suite.Run(t, new(Suite))
+func Test_Landescode_ToString(t *testing.T) {
+	then.AssertThat(t, fmt.Sprintf("%v", landescode.DE), is.EqualTo("DE"))
 }

--- a/go.mod
+++ b/go.mod
@@ -6,21 +6,18 @@ require (
 	github.com/corbym/gocrest v1.1.1
 	github.com/go-playground/validator/v10 v10.16.0
 	github.com/shopspring/decimal v1.3.1
-	github.com/stretchr/testify v1.8.4
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/leodido/go-urn v1.2.4 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -34,7 +34,6 @@ golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/market_communication/boney_comb_marktteilnehmer_test.go
+++ b/market_communication/boney_comb_marktteilnehmer_test.go
@@ -1,6 +1,8 @@
 package market_communication_test
 
 import (
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/bo"
@@ -16,69 +18,69 @@ import (
 	"github.com/hochfrequenz/go-bo4e/market_communication"
 )
 
-func (s *Suite) Test_GetAbsenderCode_Returns_Correct_Value_Without_Uri() {
+func Test_GetAbsenderCode_Returns_Correct_Value_Without_Uri(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"absender": "9876543210987",
 		},
 	}
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetAbsender(), is.NilPtr[bo.Marktteilnehmer]())
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetAbsender(), is.NilPtr[bo.Marktteilnehmer]())
 }
 
-func (s *Suite) Test_GetAbsenderCode_Returns_Correct_Value_With_Uri() {
+func Test_GetAbsenderCode_Returns_Correct_Value_With_Uri(t *testing.T) {
 	params := []struct{ transaktionsDatenValue, expectedId, testCaseInfo string }{
 		{"bo4e://Marktteilnehmer/9876543210987", "9876543210987", "Strom/Gas Sparten Id"},
 		{"bo4e://Marktteilnehmer/L34SWH", "L34SWH", "Wasser Sparten Id (kein offizielles Format definiert)"},
 	}
 
 	for _, testdata := range params {
-		s.Run(testdata.testCaseInfo, func() {
+		t.Run(testdata.testCaseInfo, func(t *testing.T) {
 			var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 				Transaktionsdaten: map[string]string{
 					"absender": testdata.transaktionsDatenValue,
 				},
 			}
-			then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo(testdata.expectedId))
+			then.AssertThat(t, *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo(testdata.expectedId))
 		})
 	}
 }
 
-func (s *Suite) Test_SetAbsenderCode() {
+func Test_SetAbsenderCode(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{}
 	boneyCombWithDokumentennummer.SetAbsenderCode("9876543210987", false)
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
 }
 
-func (s *Suite) Test_SetAbsenderCode_With_Uri() {
+func Test_SetAbsenderCode_With_Uri(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{}
 	boneyCombWithDokumentennummer.SetAbsenderCode("9876543210987", true)
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetAbsenderCode(), is.EqualTo("9876543210987"))
 }
 
-func (s *Suite) Test_GetEmpfaengerCode_Returns_Correct_Value_With_Uri() {
+func Test_GetEmpfaengerCode_Returns_Correct_Value_With_Uri(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"empfaenger": "bo4e://Marktteilnehmer/9876543210987",
 		},
 	}
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetEmpfaenger(), is.NilPtr[bo.Marktteilnehmer]())
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetEmpfaenger(), is.NilPtr[bo.Marktteilnehmer]())
 }
 
-func (s *Suite) Test_SetEmpfaengerCode() {
+func Test_SetEmpfaengerCode(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{}
 	boneyCombWithDokumentennummer.SetEmpfaengerCode("9876543210987", false)
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
 }
 
-func (s *Suite) Test_SetEmpfaengerCode_With_Uri() {
+func Test_SetEmpfaengerCode_With_Uri(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{}
 	boneyCombWithDokumentennummer.SetEmpfaengerCode("9876543210987", true)
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetEmpfaengerCode(), is.EqualTo("9876543210987"))
 }
 
-func (s *Suite) Test_GetEmpfaenger_Returns_Correct_Value_If_Present() {
+func Test_GetEmpfaenger_Returns_Correct_Value_If_Present(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Stammdaten: []bo.BusinessObject{
 			&bo.Marktteilnehmer{
@@ -160,21 +162,21 @@ func (s *Suite) Test_GetEmpfaenger_Returns_Correct_Value_If_Present() {
 			"absender":   "9903100000007",
 		},
 	}
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetEmpfaenger().BoTyp, is.EqualTo[botyp.BOTyp](boneyCombWithDokumentennummer.Stammdaten[0].GetBoTyp()))
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetAbsender().BoTyp, is.EqualTo[botyp.BOTyp](boneyCombWithDokumentennummer.Stammdaten[1].GetBoTyp()))
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetEmpfaenger().BoTyp, is.EqualTo[botyp.BOTyp](boneyCombWithDokumentennummer.Stammdaten[0].GetBoTyp()))
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetAbsender().BoTyp, is.EqualTo[botyp.BOTyp](boneyCombWithDokumentennummer.Stammdaten[1].GetBoTyp()))
 }
 
-func (s *Suite) Test_GetAbsenderCode_Returns_Nil_For_Malformed_Data() {
+func Test_GetAbsenderCode_Returns_Nil_For_Malformed_Data(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"Absender": "asdasd",
 		},
 	}
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetAbsenderCode(), is.NilPtr[string]())
-	then.AssertThat(s.T(), boneyCombWithDokumentennummer.GetAbsender(), is.NilPtr[bo.Marktteilnehmer]())
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetAbsenderCode(), is.NilPtr[string]())
+	then.AssertThat(t, boneyCombWithDokumentennummer.GetAbsender(), is.NilPtr[bo.Marktteilnehmer]())
 }
 
-func (s *Suite) Test_SetAbsender() {
+func Test_SetAbsender(t *testing.T) {
 	mt := bo.Marktteilnehmer{
 		Rollencodenummer: "9903100000006",
 		Geschaeftspartner: bo.Geschaeftspartner{
@@ -186,11 +188,11 @@ func (s *Suite) Test_SetAbsender() {
 	}
 	bc := market_communication.BOneyComb{}
 	bc.SetAbsender(mt, false)
-	then.AssertThat(s.T(), *bc.GetAbsenderCode(), is.EqualTo("9903100000006"))
-	then.AssertThat(s.T(), bc.GetAbsender(), is.EqualTo(&mt))
+	then.AssertThat(t, *bc.GetAbsenderCode(), is.EqualTo("9903100000006"))
+	then.AssertThat(t, bc.GetAbsender(), is.EqualTo(&mt))
 }
 
-func (s *Suite) Test_SetEmpfaenger() {
+func Test_SetEmpfaenger(t *testing.T) {
 	mt := bo.Marktteilnehmer{
 		Rollencodenummer: "9903100000006",
 		Geschaeftspartner: bo.Geschaeftspartner{
@@ -202,6 +204,6 @@ func (s *Suite) Test_SetEmpfaenger() {
 	}
 	bc := market_communication.BOneyComb{}
 	bc.SetEmpfaenger(mt, true)
-	then.AssertThat(s.T(), *bc.GetEmpfaengerCode(), is.EqualTo("9903100000006"))
-	then.AssertThat(s.T(), bc.GetEmpfaenger(), is.EqualTo(&mt))
+	then.AssertThat(t, *bc.GetEmpfaengerCode(), is.EqualTo("9903100000006"))
+	then.AssertThat(t, bc.GetEmpfaenger(), is.EqualTo(&mt))
 }

--- a/market_communication/boney_comb_stammdaten_test.go
+++ b/market_communication/boney_comb_stammdaten_test.go
@@ -1,6 +1,8 @@
 package market_communication_test
 
 import (
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/bo"
@@ -8,18 +10,18 @@ import (
 	"github.com/hochfrequenz/go-bo4e/market_communication"
 )
 
-func (s *Suite) Test_GetMasterDataCount_For_Empty_BoneyComb() {
+func Test_GetMasterDataCount_For_Empty_BoneyComb(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{}
-	then.AssertThat(s.T(), emptyBoneyComb.GetMasterDataCounts(), is.EqualTo(map[botyp.BOTyp]uint{}))
+	then.AssertThat(t, emptyBoneyComb.GetMasterDataCounts(), is.EqualTo(map[botyp.BOTyp]uint{}))
 }
 
-func (s *Suite) Test_GetMasterDataCount_For_Nil_Stammdaten() {
+func Test_GetMasterDataCount_For_Nil_Stammdaten(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{}
 	emptyBoneyComb.Stammdaten = nil
-	then.AssertThat(s.T(), emptyBoneyComb.GetMasterDataCounts(), is.EqualTo(map[botyp.BOTyp]uint{}))
+	then.AssertThat(t, emptyBoneyComb.GetMasterDataCounts(), is.EqualTo(map[botyp.BOTyp]uint{}))
 }
 
-func (s *Suite) Test_GetMasterDataCount() {
+func Test_GetMasterDataCount(t *testing.T) {
 	var boneyComb = market_communication.BOneyComb{
 		Stammdaten: []bo.BusinessObject{
 			bo.NewBusinessObject(botyp.MARKTTEILNEHMER),
@@ -38,17 +40,17 @@ func (s *Suite) Test_GetMasterDataCount() {
 		botyp.RECHNUNG:        1,
 		botyp.LASTGANG:        1,
 	}
-	then.AssertThat(s.T(), boneyComb.GetMasterDataCounts(), is.EqualTo(expectedResult))
+	then.AssertThat(t, boneyComb.GetMasterDataCounts(), is.EqualTo(expectedResult))
 	var expectedMarktteilnehmerCount uint = 2
 	var expectedPreisblattCount uint = 0
-	then.AssertThat(s.T(), boneyComb.GetMasterDataCount(botyp.MARKTTEILNEHMER), is.EqualTo(expectedMarktteilnehmerCount))
-	then.AssertThat(s.T(), boneyComb.ContainsAny(botyp.MESSLOKATION), is.True())
-	then.AssertThat(s.T(), boneyComb.GetMasterDataCount(botyp.PREISBLATT), is.EqualTo(expectedPreisblattCount))
-	then.AssertThat(s.T(), boneyComb.ContainsAny(botyp.PREISBLATT), is.False())
-	then.AssertThat(s.T(), boneyComb.ContainsAny(botyp.RECHNUNG), is.True())
+	then.AssertThat(t, boneyComb.GetMasterDataCount(botyp.MARKTTEILNEHMER), is.EqualTo(expectedMarktteilnehmerCount))
+	then.AssertThat(t, boneyComb.ContainsAny(botyp.MESSLOKATION), is.True())
+	then.AssertThat(t, boneyComb.GetMasterDataCount(botyp.PREISBLATT), is.EqualTo(expectedPreisblattCount))
+	then.AssertThat(t, boneyComb.ContainsAny(botyp.PREISBLATT), is.False())
+	then.AssertThat(t, boneyComb.ContainsAny(botyp.RECHNUNG), is.True())
 }
 
-func (s *Suite) Test_GetAll() {
+func Test_GetAll(t *testing.T) {
 	var boneyComb = market_communication.BOneyComb{
 		Stammdaten: []bo.BusinessObject{
 			bo.NewBusinessObject(botyp.MARKTTEILNEHMER),
@@ -60,12 +62,12 @@ func (s *Suite) Test_GetAll() {
 			bo.NewBusinessObject(botyp.LASTGANG),
 		},
 	}
-	then.AssertThat(s.T(), len(boneyComb.GetAll(botyp.PREISBLATT)), is.EqualTo(0))
-	then.AssertThat(s.T(), len(boneyComb.GetAll(botyp.MARKTTEILNEHMER)), is.EqualTo(2))
-	then.AssertThat(s.T(), len(boneyComb.GetAll(botyp.LASTGANG)), is.EqualTo(1))
+	then.AssertThat(t, len(boneyComb.GetAll(botyp.PREISBLATT)), is.EqualTo(0))
+	then.AssertThat(t, len(boneyComb.GetAll(botyp.MARKTTEILNEHMER)), is.EqualTo(2))
+	then.AssertThat(t, len(boneyComb.GetAll(botyp.LASTGANG)), is.EqualTo(1))
 }
 
-func (s *Suite) Test_GetSingle() {
+func Test_GetSingle(t *testing.T) {
 	var boneyComb = market_communication.BOneyComb{
 		Stammdaten: []bo.BusinessObject{
 			bo.NewBusinessObject(botyp.MARKTTEILNEHMER),
@@ -78,14 +80,14 @@ func (s *Suite) Test_GetSingle() {
 		},
 	}
 	marktteilnehmer, marktteilnehmerErr := boneyComb.GetSingle(botyp.MARKTTEILNEHMER) // there are 2 marktteilnehmers
-	then.AssertThat(s.T(), marktteilnehmer, is.EqualTo[bo.BusinessObject](nil))
-	then.AssertThat(s.T(), marktteilnehmerErr, is.Not(is.Nil()))
+	then.AssertThat(t, marktteilnehmer, is.EqualTo[bo.BusinessObject](nil))
+	then.AssertThat(t, marktteilnehmerErr, is.Not(is.Nil()))
 
 	preisblatt, preisblattErr := boneyComb.GetSingle(botyp.PREISBLATT) // there are 0 preisblatts
-	then.AssertThat(s.T(), preisblatt, is.EqualTo[bo.BusinessObject](nil))
-	then.AssertThat(s.T(), preisblattErr, is.Not(is.Nil()))
+	then.AssertThat(t, preisblatt, is.EqualTo[bo.BusinessObject](nil))
+	then.AssertThat(t, preisblattErr, is.Not(is.Nil()))
 
 	lastgang, lastgangErr := boneyComb.GetSingle(botyp.LASTGANG) // there is 1 lastgang
-	then.AssertThat(s.T(), lastgang, is.Not(is.EqualTo[bo.BusinessObject](nil)))
-	then.AssertThat(s.T(), lastgangErr, is.Nil())
+	then.AssertThat(t, lastgang, is.Not(is.EqualTo[bo.BusinessObject](nil)))
+	then.AssertThat(t, lastgangErr, is.Nil())
 }

--- a/market_communication/boney_comb_test.go
+++ b/market_communication/boney_comb_test.go
@@ -35,7 +35,7 @@ func TestInit(t *testing.T) {
 	suite.Run(t, new(Suite))
 }
 
-func (s *Suite) Test_BOneyComb_DeSerialization() {
+func Test_BOneyComb_DeSerialization(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{
 		Stammdaten: []bo.BusinessObject{
 			&bo.Geschaeftspartner{
@@ -83,96 +83,96 @@ func (s *Suite) Test_BOneyComb_DeSerialization() {
 	}
 	validate := validator.New()
 	validationErr := validate.Struct(boneyComb)
-	then.AssertThat(s.T(), validationErr, is.Nil())
+	then.AssertThat(t, validationErr, is.Nil())
 	serializedBoneyComb, err := json.Marshal(boneyComb)
 	//jsonString := string(serializedBoneyComb)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedBoneyComb, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedBoneyComb, is.Not(is.NilArray[byte]()))
 	var deserializedBoneyComb market_communication.BOneyComb
 	err = json.Unmarshal(serializedBoneyComb, &deserializedBoneyComb)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedBoneyComb.Stammdaten[0], is.EqualTo(boneyComb.Stammdaten[0]))
-	then.AssertThat(s.T(), deserializedBoneyComb.Stammdaten[1], is.EqualTo(boneyComb.Stammdaten[1]))
-	then.AssertThat(s.T(), deserializedBoneyComb.Stammdaten[2], is.EqualTo(boneyComb.Stammdaten[2]))
-	then.AssertThat(s.T(), deserializedBoneyComb.Transaktionsdaten, is.EqualTo(boneyComb.Transaktionsdaten))
-	then.AssertThat(s.T(), deserializedBoneyComb, is.EqualTo(boneyComb))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedBoneyComb.Stammdaten[0], is.EqualTo(boneyComb.Stammdaten[0]))
+	then.AssertThat(t, deserializedBoneyComb.Stammdaten[1], is.EqualTo(boneyComb.Stammdaten[1]))
+	then.AssertThat(t, deserializedBoneyComb.Stammdaten[2], is.EqualTo(boneyComb.Stammdaten[2]))
+	then.AssertThat(t, deserializedBoneyComb.Transaktionsdaten, is.EqualTo(boneyComb.Transaktionsdaten))
+	then.AssertThat(t, deserializedBoneyComb, is.EqualTo(boneyComb))
 }
 
-func (s *Suite) Test_Empty_BOneyComb_Is_Invalid() {
+func Test_Empty_BOneyComb_Is_Invalid(t *testing.T) {
 	validate := validator.New()
 	var emptyBoneyComb = market_communication.BOneyComb{}
 	err := validate.Struct(emptyBoneyComb)
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
-func (s *Suite) Test_BOneyComb_Without_Pruefi_Is_Invalid() {
+func Test_BOneyComb_Without_Pruefi_Is_Invalid(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(market_communication.PruefidentifikatorInTransaktionsdatenValidation, market_communication.BOneyComb{})
 	var emptyBoneyComb = market_communication.BOneyComb{}
 	err := validate.Struct(emptyBoneyComb)
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
-func (s *Suite) Test_BOneyComb_With_Wrong_Pruefi_Is_Invalid() {
+func Test_BOneyComb_With_Wrong_Pruefi_Is_Invalid(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(market_communication.PruefidentifikatorInTransaktionsdatenValidation, market_communication.BOneyComb{})
 	var boneyComb = market_communication.BOneyComb{}
 	boneyComb.SetPruefidentifikator("asdfg")
 	err := validate.Struct(boneyComb)
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
-func (s *Suite) Test_BOneyComb_With_Correct_Pruefi_Is_Valid() {
+func Test_BOneyComb_With_Correct_Pruefi_Is_Valid(t *testing.T) {
 	validate := validator.New()
 	validate.RegisterStructValidation(market_communication.PruefidentifikatorInTransaktionsdatenValidation, market_communication.BOneyComb{})
 	var boneyComb = market_communication.BOneyComb{}
 	boneyComb.SetPruefidentifikator("11042")
 	boneyComb.Stammdaten = []bo.BusinessObject{} // empty slice because nil is invalid
 	err := validate.Struct(boneyComb)
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, err, is.Nil())
 }
 
-func (s *Suite) Test_Empty_BOneyComb_With_Empty_Stammdaten_Is_Serializable() {
+func Test_Empty_BOneyComb_With_Empty_Stammdaten_Is_Serializable(t *testing.T) {
 	var boneyCombWithEmptyStammdaten = market_communication.BOneyComb{
 		Stammdaten:        []bo.BusinessObject{},
 		Transaktionsdaten: map[string]string{"foo": "bar"},
 	}
 	serializedBoneyComb, err := json.Marshal(boneyCombWithEmptyStammdaten)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), serializedBoneyComb, is.Not(is.NilArray[byte]()))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, serializedBoneyComb, is.Not(is.NilArray[byte]()))
 	var deserializedBoneyComb market_communication.BOneyComb
 	err = json.Unmarshal(serializedBoneyComb, &deserializedBoneyComb)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), deserializedBoneyComb.Stammdaten, is.EqualTo(boneyCombWithEmptyStammdaten.Stammdaten))
-	then.AssertThat(s.T(), deserializedBoneyComb.Transaktionsdaten, is.EqualTo(boneyCombWithEmptyStammdaten.Transaktionsdaten))
-	then.AssertThat(s.T(), deserializedBoneyComb, is.EqualTo(boneyCombWithEmptyStammdaten))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, deserializedBoneyComb.Stammdaten, is.EqualTo(boneyCombWithEmptyStammdaten.Stammdaten))
+	then.AssertThat(t, deserializedBoneyComb.Transaktionsdaten, is.EqualTo(boneyCombWithEmptyStammdaten.Transaktionsdaten))
+	then.AssertThat(t, deserializedBoneyComb, is.EqualTo(boneyCombWithEmptyStammdaten))
 }
 
 // Test_BOneyComb_Deserialization loops over the test_boney_combs directory and tries to deserialize all the json files there as boneycomb
-func (s *Suite) Test_BOneyComb_Deserialization() {
+func Test_BOneyComb_Deserialization(t *testing.T) {
 	const dirName = "test_boney_combs"
 	jsonFiles, err := os.ReadDir(dirName)
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), len(jsonFiles), is.Not(is.EqualTo(0)))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, len(jsonFiles), is.Not(is.EqualTo(0)))
 
 	for _, file := range jsonFiles {
 		fileContent, readErr := os.ReadFile(filepath.FromSlash(dirName + "/" + file.Name()))
-		then.AssertThat(s.T(), readErr, is.Nil())
-		then.AssertThat(s.T(), fileContent, is.Not(is.NilArray[byte]()))
+		then.AssertThat(t, readErr, is.Nil())
+		then.AssertThat(t, fileContent, is.Not(is.NilArray[byte]()))
 		var boneyComb market_communication.BOneyComb
 		err = json.Unmarshal(fileContent, &boneyComb)
-		then.AssertThat(s.T(), err, is.Nil())
-		//then.AssertThat(s.T(), boneyComb, is.Not(is.Nil())) // boneyComb is not nullable
+		then.AssertThat(t, err, is.Nil())
+		//then.AssertThat(t, boneyComb, is.Not(is.Nil())) // boneyComb is not nullable
 		if file.Name() == "20211011.json" {
 			firstMaLo, _ := boneyComb.GetSingle(botyp.MARKTLOKATION)
-			then.AssertThat(s.T(), firstMaLo.(*bo.Marktlokation).ExtensionData["some untyped prop"], is.EqualTo[any]("hello world"))
-			then.AssertThat(s.T(), boneyComb.Links["foo"][1], is.EqualTo("baz"))
+			then.AssertThat(t, firstMaLo.(*bo.Marktlokation).ExtensionData["some untyped prop"], is.EqualTo[any]("hello world"))
+			then.AssertThat(t, boneyComb.Links["foo"][1], is.EqualTo("baz"))
 		}
 		if file.Name() == "20220926.json" {
 			firstRechnung, _ := boneyComb.GetSingle(botyp.RECHNUNG)
 			expectedBuchungsdatum := time.Date(2022, 6, 01, 13, 37, 0, 0, time.UTC)
 			actualBuchungsdatum := firstRechnung.(*bo.Rechnung).Buchungsdatum
-			then.AssertThat(s.T(), actualBuchungsdatum.Unix(), is.EqualTo(expectedBuchungsdatum.Unix()))
+			then.AssertThat(t, actualBuchungsdatum.Unix(), is.EqualTo(expectedBuchungsdatum.Unix()))
 		}
 	}
 }

--- a/market_communication/boney_comb_test.go
+++ b/market_communication/boney_comb_test.go
@@ -24,16 +24,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/hochfrequenz/go-bo4e/market_communication"
 	"github.com/shopspring/decimal"
-	"github.com/stretchr/testify/suite"
 )
-
-type Suite struct {
-	suite.Suite
-}
-
-func TestInit(t *testing.T) {
-	suite.Run(t, new(Suite))
-}
 
 func Test_BOneyComb_DeSerialization(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{

--- a/market_communication/boney_comb_transaktionsdaten_test.go
+++ b/market_communication/boney_comb_transaktionsdaten_test.go
@@ -1,115 +1,117 @@
 package market_communication_test
 
 import (
+	"testing"
+	"time"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/market_communication"
-	"time"
 )
 
-func (s *Suite) Test_GetTransactionData_Returns_Nil_For_Nil_Transaktionsdaten() {
+func Test_GetTransactionData_Returns_Nil_For_Nil_Transaktionsdaten(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{}
-	then.AssertThat(s.T(), emptyBoneyComb.Transaktionsdaten, is.NilMap[string, string]())
-	then.AssertThat(s.T(), emptyBoneyComb.GetTransactionData("foo"), is.NilPtr[string]())
+	then.AssertThat(t, emptyBoneyComb.Transaktionsdaten, is.NilMap[string, string]())
+	then.AssertThat(t, emptyBoneyComb.GetTransactionData("foo"), is.NilPtr[string]())
 }
 
-func (s *Suite) Test_GetTransactionData_Returns_Nil_For_Not_Found_Key_And_Value_Otherwise() {
+func Test_GetTransactionData_Returns_Nil_For_Not_Found_Key_And_Value_Otherwise(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"foo": "bar",
 		},
 	}
-	then.AssertThat(s.T(), emptyBoneyComb.GetTransactionData("asd"), is.NilPtr[string]())
-	then.AssertThat(s.T(), emptyBoneyComb.GetTransactionData(""), is.NilPtr[string]())
-	then.AssertThat(s.T(), emptyBoneyComb.GetTransactionData("foo"), is.Not(is.NilPtr[string]()))
-	then.AssertThat(s.T(), *emptyBoneyComb.GetTransactionData("foo"), is.EqualTo("bar"))
+	then.AssertThat(t, emptyBoneyComb.GetTransactionData("asd"), is.NilPtr[string]())
+	then.AssertThat(t, emptyBoneyComb.GetTransactionData(""), is.NilPtr[string]())
+	then.AssertThat(t, emptyBoneyComb.GetTransactionData("foo"), is.Not(is.NilPtr[string]()))
+	then.AssertThat(t, *emptyBoneyComb.GetTransactionData("foo"), is.EqualTo("bar"))
 }
 
-func (s *Suite) Test_GetNachrichtendatum_Returns_Nil_For_Nil_Transaktionsdaten() {
+func Test_GetNachrichtendatum_Returns_Nil_For_Nil_Transaktionsdaten(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{}
-	then.AssertThat(s.T(), emptyBoneyComb.Transaktionsdaten, is.NilMap[string, string]())
+	then.AssertThat(t, emptyBoneyComb.Transaktionsdaten, is.NilMap[string, string]())
 	nachrichtendatum, err := emptyBoneyComb.GetNachrichtendatum()
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), nachrichtendatum, is.NilPtr[time.Time]())
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, nachrichtendatum, is.NilPtr[time.Time]())
 }
 
-func (s *Suite) Test_GetNachrichtendatum_Returns_Error_For_Unparsable_Date() {
+func Test_GetNachrichtendatum_Returns_Error_For_Unparsable_Date(t *testing.T) {
 	var boneyCombWithMalformedDate = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"nachrichtendatum": "adasdasd",
 		},
 	}
 	nachrichtendatum, err := boneyCombWithMalformedDate.GetNachrichtendatum()
-	then.AssertThat(s.T(), nachrichtendatum, is.NilPtr[time.Time]())
-	then.AssertThat(s.T(), err, is.Not(is.Nil()))
+	then.AssertThat(t, nachrichtendatum, is.NilPtr[time.Time]())
+	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
-func (s *Suite) Test_GetNachrichtendatum_Returns_Correct_Value() {
+func Test_GetNachrichtendatum_Returns_Correct_Value(t *testing.T) {
 	var boneyCombWithMalformedDate = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"nachrichtendatum": "2021-10-14T15:35:00Z",
 		},
 	}
 	nachrichtendatum, err := boneyCombWithMalformedDate.GetNachrichtendatum()
-	then.AssertThat(s.T(), *nachrichtendatum, is.EqualTo(time.Date(2021, 10, 14, 15, 35, 0, 0, time.UTC)))
-	then.AssertThat(s.T(), err, is.Nil())
+	then.AssertThat(t, *nachrichtendatum, is.EqualTo(time.Date(2021, 10, 14, 15, 35, 0, 0, time.UTC)))
+	then.AssertThat(t, err, is.Nil())
 }
 
-func (s *Suite) Test_SetNachrichtendatum() {
+func Test_SetNachrichtendatum(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{}
 	arbitraryDate := time.Date(2021, 10, 24, 16, 32, 0, 0, time.UTC)
 	boneyComb.SetNachrichtendatum(arbitraryDate)
 	setDate, err := boneyComb.GetNachrichtendatum()
-	then.AssertThat(s.T(), err, is.Nil())
-	then.AssertThat(s.T(), *setDate, is.EqualTo(arbitraryDate))
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, *setDate, is.EqualTo(arbitraryDate))
 }
 
-func (s *Suite) Test_GetDokumentennummer_Returns_Correct_Value() {
+func Test_GetDokumentennummer_Returns_Correct_Value(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"dokumentennummer": "asdasdasd",
 		},
 	}
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetDokumentennummer(), is.EqualTo("asdasdasd"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetDokumentennummer(), is.EqualTo("asdasdasd"))
 }
 
-func (s *Suite) Test_SetDokumentennummer() {
+func Test_SetDokumentennummer(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{}
 	boneyComb.SetDokumentennummer("1234567ASDFGH")
-	then.AssertThat(s.T(), *boneyComb.GetDokumentennummer(), is.EqualTo("1234567ASDFGH"))
+	then.AssertThat(t, *boneyComb.GetDokumentennummer(), is.EqualTo("1234567ASDFGH"))
 }
 
-func (s *Suite) Test_GtNachrichtenReferenznummer_Returns_Correct_Value() {
+func Test_GtNachrichtenReferenznummer_Returns_Correct_Value(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"nachrichtenReferenznummer": "asdasdasd",
 		},
 	}
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetNachrichtenReferenznummer(), is.EqualTo("asdasdasd"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetNachrichtenReferenznummer(), is.EqualTo("asdasdasd"))
 }
 
-func (s *Suite) Test_SetNachrichtenReferenznummer() {
+func Test_SetNachrichtenReferenznummer(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{}
 	boneyComb.SetNachrichtenReferenznummer("1234567ASDFGH")
-	then.AssertThat(s.T(), *boneyComb.GetNachrichtenReferenznummer(), is.EqualTo("1234567ASDFGH"))
+	then.AssertThat(t, *boneyComb.GetNachrichtenReferenznummer(), is.EqualTo("1234567ASDFGH"))
 }
 
-func (s *Suite) Test_GetPruefidentifikator_Returns_Correct_Value() {
+func Test_GetPruefidentifikator_Returns_Correct_Value(t *testing.T) {
 	var boneyCombWithDokumentennummer = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"pruefidentifikator": "13002",
 		},
 	}
-	then.AssertThat(s.T(), *boneyCombWithDokumentennummer.GetPruefidentifikator(), is.EqualTo("13002"))
+	then.AssertThat(t, *boneyCombWithDokumentennummer.GetPruefidentifikator(), is.EqualTo("13002"))
 }
 
-func (s *Suite) Test_GetDokumentennummer() {
+func Test_GetDokumentennummer(t *testing.T) {
 	boneyComb := market_communication.BOneyComb{}
 	boneyComb.SetPruefidentifikator("11042")
-	then.AssertThat(s.T(), *boneyComb.GetPruefidentifikator(), is.EqualTo("11042"))
+	then.AssertThat(t, *boneyComb.GetPruefidentifikator(), is.EqualTo("11042"))
 }
 
-func (s *Suite) Test_GetTransaktionsdatenKeys() {
+func Test_GetTransaktionsdatenKeys(t *testing.T) {
 	var boneyComb = market_communication.BOneyComb{
 		Transaktionsdaten: map[string]string{
 			"ZZZ":              "z",
@@ -118,10 +120,10 @@ func (s *Suite) Test_GetTransaktionsdatenKeys() {
 			"Asd":              "xyz",
 		},
 	}
-	then.AssertThat(s.T(), boneyComb.GetTransaktionsdatenKeys(), is.EqualTo([]string{"Asd", "Foo", "ZZZ", "nachrichtendatum"}))
+	then.AssertThat(t, boneyComb.GetTransaktionsdatenKeys(), is.EqualTo([]string{"Asd", "Foo", "ZZZ", "nachrichtendatum"}))
 }
 
-func (s *Suite) Test_GetTransaktionsdatenKeys_Works_For_Nil() {
+func Test_GetTransaktionsdatenKeys_Works_For_Nil(t *testing.T) {
 	var emptyBoneyComb = market_communication.BOneyComb{}
-	then.AssertThat(s.T(), emptyBoneyComb.GetTransaktionsdatenKeys(), is.EqualTo([]string{}))
+	then.AssertThat(t, emptyBoneyComb.GetTransaktionsdatenKeys(), is.EqualTo([]string{}))
 }

--- a/market_communication/key_generation_test.go
+++ b/market_communication/key_generation_test.go
@@ -1,23 +1,25 @@
 package market_communication_test
 
 import (
+	"regexp"
+	"testing"
+
 	"github.com/corbym/gocrest/is"
 	"github.com/corbym/gocrest/then"
 	"github.com/hochfrequenz/go-bo4e/market_communication"
-	"regexp"
 )
 
 var expectedBgmPattern = regexp.MustCompile(`[A-Z\d]{35}`)
 var expectedUnhPattern = regexp.MustCompile(`[A-Z\d]{14}`)
 
-func (s *Suite) Test_GenerationRandomDokumentennummer() {
+func Test_GenerationRandomDokumentennummer(t *testing.T) {
 	actual := market_communication.GenerateRandomDokumentennummer()
-	then.AssertThat(s.T(), expectedBgmPattern.MatchString(actual), is.True())
+	then.AssertThat(t, expectedBgmPattern.MatchString(actual), is.True())
 }
 
-func (s *Suite) Test_GenerationRandomNachrichtenReferenznummer() {
+func Test_GenerationRandomNachrichtenReferenznummer(t *testing.T) {
 	actual := market_communication.GenerateRandomNachrichtenReferenznummer()
-	then.AssertThat(s.T(), expectedUnhPattern.MatchString(actual), is.True())
+	then.AssertThat(t, expectedUnhPattern.MatchString(actual), is.True())
 }
 
 const numberOfTries = 1000 // <-- the higher the more "random" the functions return values are
@@ -31,10 +33,10 @@ func funcGeneratesDuplicates(stringGenerator func() string) bool {
 	return len(set) != numberOfTries
 }
 
-func (s *Suite) Test_RandomDokumentennummer_Is_Random_Enough() {
-	then.AssertThat(s.T(), funcGeneratesDuplicates(market_communication.GenerateRandomDokumentennummer), is.False())
+func Test_RandomDokumentennummer_Is_Random_Enough(t *testing.T) {
+	then.AssertThat(t, funcGeneratesDuplicates(market_communication.GenerateRandomDokumentennummer), is.False())
 }
 
-func (s *Suite) Test_RandomNachrichtenReferenznummer_Is_Random_Enough() {
-	then.AssertThat(s.T(), funcGeneratesDuplicates(market_communication.GenerateRandomNachrichtenReferenznummer), is.False())
+func Test_RandomNachrichtenReferenznummer_Is_Random_Enough(t *testing.T) {
+	then.AssertThat(t, funcGeneratesDuplicates(market_communication.GenerateRandomNachrichtenReferenznummer), is.False())
 }


### PR DESCRIPTION
This removes the [suite package](https://pkg.go.dev/github.com/stretchr/testify/suite) from the tests. No features of the package were used actually:

* Some methods that are executed before every test, suite, or after, etc. were implemented, but empty.
* Helper methods `Require` and `Assert` weren't used, and even if they would have been, they're just wrappers around `assert.New(t)`.

Instead, the package took away the parallelizing functionality from the native Go package. Example:

```go
package parallel_test

import (
	"testing"
	"time"

	"github.com/stretchr/testify/suite"
)

type Suite struct {
	suite.Suite
}

func TestInit(t *testing.T) {
	suite.Run(t, new(Suite))
}

func (s *Suite) TestParallel1() {
	s.T().Parallel()
	assert := s.Assert()

	time.Sleep(time.Millisecond * 2)

	assert.True(false)
}

func (s *Suite) TestParallel2() {
	s.T().Parallel()
	time.Sleep(time.Millisecond)

	_ = s.Assert()

	time.Sleep(time.Millisecond * 2)
}
```
When running these tests:
```
$ go test
--- FAIL: TestInit (0.00s)
    --- FAIL: TestInit/TestParallel2 (0.00s)
        main_test.go:24: 
            	Error Trace:	/home/godsboss/github.com/GodsBoss/testsuite-parallel/main_test.go:24
            	Error:      	Should be true
            	Test:       	TestInit/TestParallel2
FAIL
exit status 1
FAIL	github.com/GodsBoss/testsuite-parallel	0.006s
```
Note that the failing test is reported for the test `TestParallel2` despite the test failure being in `TestParallel1`.

In addition, some of the tests for the `COM/Zaehlwerk` type depended implicitly on test execution order. They're now independent.