### PR TITLE
Add non-panicking MaLo ID checksum function

### DIFF
--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -99,6 +99,8 @@ func MaloIdFieldLevelValidation(fl validator.FieldLevel) bool {
 }
 
 // GetMaLoIdCheckSum returns the checksum (11th character of the malo ID) that matches the first ten characters long provided in maloIdWithoutCheckSum. This is going to crash if the length of the maloIdWithoutCheckSum is <10
+//
+// Deprecated: Use CalculateMaLoIdCheckSum which provides error handling and doesn't panic.
 func GetMaLoIdCheckSum(maloIdWithoutCheckSum string) int {
 	evenSum := 0
 	oddSum := 0

--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -2,6 +2,8 @@ package bo
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/hochfrequenz/go-bo4e/enum/messtechnischeeinordnung"
@@ -110,6 +112,48 @@ func GetMaLoIdCheckSum(maloIdWithoutCheckSum string) int {
 	}
 	stepC := oddSum + (evenSum * 2)
 	return (10 - (stepC % 10)) % 10
+}
+
+// CalculateMaLoIdCheckSum calculates the checksum (last digit) for the given malo ID. Takes both the 10-digit part of a MaLo or the whole MaLo (11 digits).
+// Returns an error if maloID's length is neither 10 nor 11, or if the first ten characters do not constitute a maloID.
+func CalculateMaLoIdCheckSum(maloID string) (int, error) {
+	if len(maloID) < 10 {
+		return -1, fmt.Errorf("given maloID '%s' is too short", maloID)
+	}
+	if len(maloID) > 11 {
+		return -1, fmt.Errorf("given maloID '%s' is too long", maloID)
+	}
+
+	errs := make([]error, 0)
+	if first := maloID[0] - '0'; first < 1 || first > 9 {
+		errs = append(errs, fmt.Errorf("first char must be a digit from 1-9, is '%c'", maloID[0]))
+	}
+
+	evenSum, oddSum := 0, 0
+
+	for index, digitRune := range maloID[:10] {
+		digit := int(digitRune - '0')
+		if digit < 0 || digit > 9 {
+			errs = append(errs, fmt.Errorf("char at index %d must be a digit from 0-9, is '%c'", index, digitRune))
+		}
+
+		// Note: The specification for the MaLo defines the position such that the first digit has the position 1,
+		// unlike indexing in Go, which starts at 0. To avoid confusion, we explicitly define the position here.
+		position := index + 1
+
+		if position%2 == 0 {
+			evenSum += digit
+		} else {
+			oddSum += digit
+		}
+	}
+
+	if err := errors.Join(errs...); err != nil {
+		return -1, fmt.Errorf("could not calculate MaLo checksum for '%s': %w", maloID, err)
+	}
+
+	sum := oddSum + (evenSum * 2)
+	return (10 - (sum % 10)) % 10, nil
 }
 
 // XorStructLevelValidation ensures that only one of the possible address types is given

--- a/bo/marktlokation_test.go
+++ b/bo/marktlokation_test.go
@@ -306,6 +306,76 @@ func Test_Get_MaloId_Checksum(t *testing.T) {
 	then.AssertThat(t, actual, is.EqualTo(1))
 }
 
+func TestCalculateMaLoIdCheckSum(t *testing.T) {
+	t.Run(
+		"success",
+		func(t *testing.T) {
+			testcases := map[string]struct {
+				maLoID                string
+				expectedChecksumDigit int
+			}{
+				"checksum digit not included": {
+					maLoID:                "5123869678",
+					expectedChecksumDigit: 1,
+				},
+				"checksum digit included": {
+					maLoID:                "51238696781",
+					expectedChecksumDigit: 1,
+				},
+			}
+
+			for name := range testcases {
+				testcase := testcases[name]
+
+				t.Run(
+					name,
+					func(t *testing.T) {
+						checksumDigit, err := bo.CalculateMaLoIdCheckSum(testcase.maLoID)
+
+						then.AssertThat(t, err, is.Nil())
+						then.AssertThat(t, checksumDigit, is.EqualTo(testcase.expectedChecksumDigit))
+					},
+				)
+			}
+		},
+	)
+
+	t.Run(
+		"failure",
+		func(t *testing.T) {
+			testcases := map[string]struct {
+				maloID string
+			}{
+				"too short": {
+					maloID: "12345",
+				},
+				"too long": {
+					maloID: "12345678901234567890",
+				},
+				"first digit is 0": {
+					maloID: "0123456789",
+				},
+				"invalid character in ID": {
+					"1234XXX890",
+				},
+			}
+
+			for name := range testcases {
+				testcase := testcases[name]
+
+				t.Run(
+					name,
+					func(t *testing.T) {
+						_, err := bo.CalculateMaLoIdCheckSum(testcase.maloID)
+
+						then.AssertThat(t, err, is.Not(is.Nil()))
+					},
+				)
+			}
+		},
+	)
+}
+
 func Test_Empty_Marktlokation_Is_Creatable_Using_BoTyp(t *testing.T) {
 	object := bo.NewBusinessObject(botyp.MARKTLOKATION)
 	then.AssertThat(t, object, is.Not(is.EqualTo[bo.BusinessObject](nil)))


### PR DESCRIPTION
This adds a new function, `CalculateMaLoIdCheckSum`, that calculates the checksum for a given MaLoID or the first 10 digits of a MaLoID. The existing function, `GetMaLoIdCheckSum`, is marked as deprecated, but kept for backwards-compatibility.