### PR TITLE
Make Energiemenge.Lokationstyp nullable

### DIFF
--- a/bo/businessobject_slice_test.go
+++ b/bo/businessobject_slice_test.go
@@ -50,7 +50,7 @@ var SliceWithThreeValidBos = bo.BusinessObjectSlice{
 			VersionStruktur: "1",
 		},
 		LokationsId:  "54321012345",
-		LokationsTyp: lokationstyp.MALO,
+		LokationsTyp: internal.Ptr(lokationstyp.MALO),
 		Verbrauch: []com.Verbrauch{
 			{
 				Startdatum:               time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),

--- a/bo/energiemenge.go
+++ b/bo/energiemenge.go
@@ -8,9 +8,9 @@ import (
 // Energiemenge contains information about consumption at a location
 type Energiemenge struct {
 	Geschaeftsobjekt
-	LokationsId  string                    `json:"lokationsId,omitempty" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
-	LokationsTyp lokationstyp.Lokationstyp `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                                    // LokationsTyp is the type of the location in LokationsId
-	Verbrauch    []com.Verbrauch           `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Verbrauch are consumption data
+	LokationsId  string                     `json:"lokationsId,omitempty" example:"DE0123456789012345678901234567890" validate:"alphanum,required,min=11,max=33"` // LokationsId is the ID of the location (either a LokationsTyp MALO ID (11 digits) or a LokationsTyp MELO ID (33 alphanum))
+	LokationsTyp *lokationstyp.Lokationstyp `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                                    // LokationsTyp is the type of the location in LokationsId
+	Verbrauch    []com.Verbrauch            `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Verbrauch are consumption data
 }
 
 func (_ Energiemenge) GetDefaultJsonTags() []string {

--- a/bo/energiemenge_test.go
+++ b/bo/energiemenge_test.go
@@ -1,6 +1,7 @@
 package bo_test
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/lokationstyp"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
+	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
 )
 
@@ -37,7 +39,7 @@ func Test_Failed_EnergiemengeValidation(t *testing.T) {
 					ExterneReferenzen: nil,
 				},
 				LokationsId:  "",
-				LokationsTyp: 0,
+				LokationsTyp: internal.Ptr(lokationstyp.Lokationstyp(0)),
 				Verbrauch:    nil,
 			},
 		},
@@ -49,7 +51,7 @@ func Test_Failed_EnergiemengeValidation(t *testing.T) {
 					ExterneReferenzen: nil,
 				},
 				LokationsId:  "not11len",
-				LokationsTyp: lokationstyp.MELO,
+				LokationsTyp: internal.Ptr(lokationstyp.MELO),
 				Verbrauch:    []com.Verbrauch{verbrauch},
 			},
 		},
@@ -61,7 +63,7 @@ func Test_Failed_EnergiemengeValidation(t *testing.T) {
 					ExterneReferenzen: nil,
 				},
 				LokationsId:  "not alpha numeric",
-				LokationsTyp: lokationstyp.MELO,
+				LokationsTyp: internal.Ptr(lokationstyp.MELO),
 				Verbrauch:    []com.Verbrauch{verbrauch},
 			},
 		},
@@ -88,11 +90,36 @@ func Test_Successful_EnergiemengeValidation(t *testing.T) {
 				ExterneReferenzen: nil,
 			},
 			LokationsId:  "54321098765",
-			LokationsTyp: lokationstyp.MELO,
+			LokationsTyp: internal.Ptr(lokationstyp.MELO),
 			Verbrauch:    []com.Verbrauch{verbrauch},
 		},
 	}
 	VerifySuccessfulValidations(t, validate, validEnergiemengen)
+}
+
+func TestEnergiemengeDeserializeExplicitNulls(t *testing.T) {
+	testcases := map[string]struct {
+		raw string
+	}{
+		"lokationstyp": {
+			raw: `{
+				"boTyp": "ENERGIEMENGE",
+				"versionStruktur":"1",
+				"lokationsTyp": null
+			}`,
+		},
+	}
+
+	for name := range testcases {
+		testcase := testcases[name]
+
+		t.Run(
+			name,
+			func(t *testing.T) {
+				then.AssertThat(t, json.Unmarshal([]byte(testcase.raw), &bo.Energiemenge{}), is.Nil())
+			},
+		)
+	}
 }
 
 func Test_Empty_Energiemenge_Is_Creatable_Using_BoTyp(t *testing.T) {

--- a/bo/lastgang_test.go
+++ b/bo/lastgang_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/messwertstatuszusatz"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
+	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/shopspring/decimal"
 )
 
@@ -104,7 +105,7 @@ func Test_Successful_Lastgang_Validation(t *testing.T) {
 				ExterneReferenzen: nil,
 			},
 			LokationsId:  "54321098765",
-			LokationsTyp: lokationstyp.MELO,
+			LokationsTyp: internal.Ptr(lokationstyp.MELO),
 			Verbrauch:    []com.Verbrauch{verbrauch},
 		},
 	}

--- a/market_communication/boney_comb_test.go
+++ b/market_communication/boney_comb_test.go
@@ -55,7 +55,7 @@ func Test_BOneyComb_DeSerialization(t *testing.T) {
 					VersionStruktur: "1",
 				},
 				LokationsId:  "54321012345",
-				LokationsTyp: lokationstyp.MALO,
+				LokationsTyp: internal.Ptr(lokationstyp.MALO),
 				Verbrauch: []com.Verbrauch{
 					{
 						Startdatum:               time.Date(2021, 8, 1, 0, 0, 0, 0, time.UTC),


### PR DESCRIPTION
Lokationstyp is nullable in [.NET package's Energiemenge](https://github.com/Hochfrequenz/BO4E-dotnet/blob/main/BO4E/BO/Energiemenge.cs), so make it nullable in Go lib as well.