### PR TITLE
Generify deserialization testcases.

### DIFF
--- a/bo/bilanzierung_test.go
+++ b/bo/bilanzierung_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/prognosegrundlage"
 	"github.com/hochfrequenz/go-bo4e/enum/zeitreihentyp"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/testcase"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
 )
@@ -85,56 +86,35 @@ func Test_Bilanzierung_Deserialization(t *testing.T) {
 }
 
 func TestBilanzierungDeserializeExplicitNulls(t *testing.T) {
-	testcases := map[string]struct {
-		raw string
-	}{
-		"marktlokationsId": {
-			raw: `{
-				"boTyp":"BILANZIERUNG",
-				"versionStruktur":"1",
-				"marktlokationsId": null
-			}`,
-		},
-		"zeitreihentyp": {
-			raw: `{
-				"boTyp":"BILANZIERUNG",
-				"versionStruktur":"1",
-				"zeitreihentyp": null
-			}`,
-		},
-		"aggregationsverantwortung": {
-			raw: `{
-				"boTyp":"BILANZIERUNG",
-				"versionStruktur":"1",
-				"aggregationsverantwortung": null
-			}`,
-		},
-		"prognosegrundlage": {
-			raw: `{
-				"boTyp":"BILANZIERUNG",
-				"versionStruktur":"1",
-				"prognosegrundlage":null
-			}`,
-		},
-		"fallgruppenzuordnung": {
-			raw: `{
-				"boTyp":"BILANZIERUNG",
-				"versionStruktur":"1",
-				"fallgruppenzuordnung":null
-			}`,
-		},
+	testcases := testcase.Map[testcase.JSONDeserializationSucceeds[bo.Bilanzierung]]{
+		"marktlokationsId": `{
+			"boTyp":"BILANZIERUNG",
+			"versionStruktur":"1",
+			"marktlokationsId": null
+		}`,
+		"zeitreihentyp": `{
+			"boTyp":"BILANZIERUNG",
+			"versionStruktur":"1",
+			"zeitreihentyp": null
+		}`,
+		"aggregationsverantwortung": `{
+			"boTyp":"BILANZIERUNG",
+			"versionStruktur":"1",
+			"aggregationsverantwortung": null
+		}`,
+		"prognosegrundlage": `{
+			"boTyp":"BILANZIERUNG",
+			"versionStruktur":"1",
+			"prognosegrundlage":null
+		}`,
+		"fallgruppenzuordnung": `{
+			"boTyp":"BILANZIERUNG",
+			"versionStruktur":"1",
+			"fallgruppenzuordnung":null
+		}`,
 	}
 
-	for name := range testcases {
-		testcase := testcases[name]
-
-		t.Run(
-			name,
-			func(t *testing.T) {
-				then.AssertThat(t, json.Unmarshal([]byte(testcase.raw), &bo.Bilanzierung{}), is.Nil())
-			},
-		)
-	}
+	testcases.Run(t)
 }
 
 func Test_Bilanzierung_Deserializes_Unknown_Fields(t *testing.T) {

--- a/bo/energiemenge_test.go
+++ b/bo/energiemenge_test.go
@@ -1,7 +1,6 @@
 package bo_test
 
 import (
-	"encoding/json"
 	"reflect"
 	"testing"
 	"time"
@@ -16,6 +15,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/enum/wertermittlungsverfahren"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/testcase"
 	"github.com/shopspring/decimal"
 )
 
@@ -98,28 +98,15 @@ func Test_Successful_EnergiemengeValidation(t *testing.T) {
 }
 
 func TestEnergiemengeDeserializeExplicitNulls(t *testing.T) {
-	testcases := map[string]struct {
-		raw string
-	}{
-		"lokationstyp": {
-			raw: `{
-				"boTyp": "ENERGIEMENGE",
-				"versionStruktur":"1",
-				"lokationsTyp": null
-			}`,
-		},
+	testcases := testcase.Map[testcase.JSONDeserializationSucceeds[bo.Energiemenge]]{
+		"lokationstyp": `{
+			"boTyp": "ENERGIEMENGE",
+			"versionStruktur":"1",
+			"lokationsTyp": null
+		}`,
 	}
 
-	for name := range testcases {
-		testcase := testcases[name]
-
-		t.Run(
-			name,
-			func(t *testing.T) {
-				then.AssertThat(t, json.Unmarshal([]byte(testcase.raw), &bo.Energiemenge{}), is.Nil())
-			},
-		)
-	}
+	testcases.Run(t)
 }
 
 func Test_Empty_Energiemenge_Is_Creatable_Using_BoTyp(t *testing.T) {

--- a/internal/testcase/deserialization.go
+++ b/internal/testcase/deserialization.go
@@ -1,0 +1,19 @@
+package testcase
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/corbym/gocrest/is"
+	"github.com/corbym/gocrest/then"
+)
+
+// JSONDeserializationSucceeds is a simple testcase that just tests that a given string can be JSON-deserialized into an entity type.
+type JSONDeserializationSucceeds[Entity any] string
+
+// Run tests whether deserializing the raw string represented by this testcase into a pointer to a value of type Entity succeeds.
+func (tc JSONDeserializationSucceeds[Entity]) Run(t *testing.T) {
+	t.Parallel()
+	var entity Entity
+	then.AssertThat(t, json.Unmarshal([]byte(tc), &entity), is.Nil())
+}

--- a/internal/testcase/map.go
+++ b/internal/testcase/map.go
@@ -1,0 +1,19 @@
+package testcase
+
+import "testing"
+
+// Map contains testcases. It maps names of subtests to testcases.
+type Map[TC Testcase] map[string]TC
+
+// Run runs all the tests contained in m as subtests.
+func (m Map[TC]) Run(t *testing.T) {
+	for name := range m {
+		t.Run(name, m[name].Run)
+	}
+}
+
+// Testcase represents any testcase.
+type Testcase interface {
+	// Run execute the testcase.
+	Run(t *testing.T)
+}


### PR DESCRIPTION
Makes writing deserialization testcases easier. Maybe other tests could be enhanced as well.