### PR TITLE
Make nullability of Preisblatt fields consistent with .NET lib

### DIFF
--- a/bo/preisblatt.go
+++ b/bo/preisblatt.go
@@ -13,7 +13,7 @@ import (
 type Preisblatt struct {
 	Geschaeftsobjekt
 	Bezeichnung     string                   `json:"bezeichnung" validate:"required"`           // Rechnungstitel ist die Bezeichnung für die vorliegende Rechnung.
-	Sparte          sparte.Sparte            `json:"sparte,omitempty" validate:"required"`      // Preisblatt gilt für angegebene Sparte.
+	Sparte          *sparte.Sparte           `json:"sparte,omitempty" validate:"required"`      // Preisblatt gilt für angegebene Sparte.
 	Preisstatus     *preisstatus.Preisstatus `json:"preisstatus,omitempty" validate:"required"` // Merkmal, das anzeigt, ob es sich um vorläufige oder endgültige Preise handelt
 	Herausgeber     Marktteilnehmer          `json:"herausgeber" validate:"required"`           // Der Marktteilnehmer, der die Preise veröffentlicht hat. Details zum Marktteilnehmer
 	Gueltigkeit     com.Zeitraum             `json:"gueltigkeit" validate:"required"`           // Der Zeitraum für den der Preis festgelegt ist

--- a/bo/preisblatt.go
+++ b/bo/preisblatt.go
@@ -12,12 +12,12 @@ import (
 // verschiedenen Anwendungsfälle der Preisblätter dar.
 type Preisblatt struct {
 	Geschaeftsobjekt
-	Bezeichnung     string                  `json:"bezeichnung" validate:"required"`           // Rechnungstitel ist die Bezeichnung für die vorliegende Rechnung.
-	Sparte          sparte.Sparte           `json:"sparte,omitempty" validate:"required"`      // Preisblatt gilt für angegebene Sparte.
-	Preisstatus     preisstatus.Preisstatus `json:"preisstatus,omitempty" validate:"required"` // Merkmal, das anzeigt, ob es sich um vorläufige oder endgültige Preise handelt
-	Herausgeber     Marktteilnehmer         `json:"herausgeber" validate:"required"`           // Der Marktteilnehmer, der die Preise veröffentlicht hat. Details zum Marktteilnehmer
-	Gueltigkeit     com.Zeitraum            `json:"gueltigkeit" validate:"required"`           // Der Zeitraum für den der Preis festgelegt ist
-	Preispositionen []com.Preisposition     `json:"preispositionen" validate:"required"`       // Die einzelnen Positionen, die mit dem Preisblatt abgerechnet werden können. Z.B. Arbeitspreis, Grundpreis etc
+	Bezeichnung     string                   `json:"bezeichnung" validate:"required"`           // Rechnungstitel ist die Bezeichnung für die vorliegende Rechnung.
+	Sparte          sparte.Sparte            `json:"sparte,omitempty" validate:"required"`      // Preisblatt gilt für angegebene Sparte.
+	Preisstatus     *preisstatus.Preisstatus `json:"preisstatus,omitempty" validate:"required"` // Merkmal, das anzeigt, ob es sich um vorläufige oder endgültige Preise handelt
+	Herausgeber     Marktteilnehmer          `json:"herausgeber" validate:"required"`           // Der Marktteilnehmer, der die Preise veröffentlicht hat. Details zum Marktteilnehmer
+	Gueltigkeit     com.Zeitraum             `json:"gueltigkeit" validate:"required"`           // Der Zeitraum für den der Preis festgelegt ist
+	Preispositionen []com.Preisposition      `json:"preispositionen" validate:"required"`       // Die einzelnen Positionen, die mit dem Preisblatt abgerechnet werden können. Z.B. Arbeitspreis, Grundpreis etc
 }
 
 func (_ Preisblatt) GetDefaultJsonTags() []string {

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -36,7 +36,7 @@ func Test_Preisblatt_Deserialization(t *testing.T) {
 			ExterneReferenzen: nil,
 		},
 		Bezeichnung: "Preisblatt",
-		Sparte:      sparte.STROM,
+		Sparte:      internal.Ptr(sparte.STROM),
 		Preisstatus: internal.Ptr(preisstatus.ENDGUELTIG),
 		Herausgeber: bo.Marktteilnehmer{
 			Geschaeftspartner: bo.Geschaeftspartner{
@@ -108,7 +108,7 @@ func Test_Failed_PreisblattValidation(t *testing.T) {
 					ExterneReferenzen: nil,
 				},
 				Bezeichnung:     "",
-				Sparte:          0,
+				Sparte:          internal.Ptr(sparte.Sparte(0)),
 				Preisstatus:     internal.Ptr(preisstatus.Preisstatus(0)),
 				Herausgeber:     bo.Marktteilnehmer{},
 				Gueltigkeit:     com.Zeitraum{},
@@ -134,7 +134,7 @@ func Test_Successful_Preisblatt_Validation(t *testing.T) {
 				ExterneReferenzen: nil,
 			},
 			Bezeichnung: "Preisblatt",
-			Sparte:      sparte.STROM,
+			Sparte:      internal.Ptr(sparte.STROM),
 			Preisstatus: internal.Ptr(preisstatus.ENDGUELTIG),
 			Herausgeber: bo.Marktteilnehmer{
 				Geschaeftspartner: bo.Geschaeftspartner{
@@ -188,6 +188,11 @@ func TestPreisblattDeserializeExplicitNulls(t *testing.T) {
 			"boTyp": "PREISBLATT",
 			"versionStruktur": "1",
 			"preisstatus": null
+		}`,
+		"sparte": `{
+			"boTyp": "PREISBLATT",
+			"versionStruktur": "1",
+			"sparte": null
 		}`,
 	}
 

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungseinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/testcase"
 	"github.com/shopspring/decimal"
 )
 
@@ -36,7 +37,7 @@ func Test_Preisblatt_Deserialization(t *testing.T) {
 		},
 		Bezeichnung: "Preisblatt",
 		Sparte:      sparte.STROM,
-		Preisstatus: preisstatus.ENDGUELTIG,
+		Preisstatus: internal.Ptr(preisstatus.ENDGUELTIG),
 		Herausgeber: bo.Marktteilnehmer{
 			Geschaeftspartner: bo.Geschaeftspartner{
 				Geschaeftsobjekt: bo.Geschaeftsobjekt{
@@ -108,7 +109,7 @@ func Test_Failed_PreisblattValidation(t *testing.T) {
 				},
 				Bezeichnung:     "",
 				Sparte:          0,
-				Preisstatus:     0,
+				Preisstatus:     internal.Ptr(preisstatus.Preisstatus(0)),
 				Herausgeber:     bo.Marktteilnehmer{},
 				Gueltigkeit:     com.Zeitraum{},
 				Preispositionen: nil,
@@ -134,7 +135,7 @@ func Test_Successful_Preisblatt_Validation(t *testing.T) {
 			},
 			Bezeichnung: "Preisblatt",
 			Sparte:      sparte.STROM,
-			Preisstatus: preisstatus.ENDGUELTIG,
+			Preisstatus: internal.Ptr(preisstatus.ENDGUELTIG),
 			Herausgeber: bo.Marktteilnehmer{
 				Geschaeftspartner: bo.Geschaeftspartner{
 					Geschaeftsobjekt: bo.Geschaeftsobjekt{
@@ -179,4 +180,16 @@ func Test_Empty_Preisblatt_Is_Creatable_Using_BoTyp(t *testing.T) {
 
 func Test_Serialized_Empty_Preisblatt_Contains_No_Enum_Defaults(t *testing.T) {
 	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.PREISBLATT))
+}
+
+func TestPreisblattDeserializeExplicitNulls(t *testing.T) {
+	testcases := testcase.Map[testcase.JSONDeserializationSucceeds[bo.Preisblatt]]{
+		"preisstatus": `{
+			"boTyp": "PREISBLATT",
+			"versionStruktur": "1",
+			"preisstatus": null
+		}`,
+	}
+
+	testcases.Run(t)
 }


### PR DESCRIPTION
Makes Preisblatt.Sparte and Preisblatt.Preisstatus nullable, just as they are in [Preisblatt.cs](https://github.com/Hochfrequenz/BO4E-dotnet/blob/main/BO4E/BO/Preisblatt.cs).