### PR TITLE
Make Zaehler.Zaehlertyp nullable.

### DIFF
--- a/bo/businessobject_slice_test.go
+++ b/bo/businessobject_slice_test.go
@@ -41,7 +41,7 @@ var SliceWithThreeValidBos = bo.BusinessObjectSlice{
 		Sparte:             sparte.STROM,
 		Zaehlernummer:      "1ASD23",
 		Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-		Zaehlertyp:         zaehlertyp.DREHKOLBENZAEHLER,
+		Zaehlertyp:         internal.Ptr(zaehlertyp.DREHKOLBENZAEHLER),
 		Tarifart:           internal.Ptr(tarifart.EINTARIF),
 	},
 	&bo.Energiemenge{

--- a/bo/messlokation_test.go
+++ b/bo/messlokation_test.go
@@ -59,7 +59,7 @@ func Test_Messlokation_Deserialization(t *testing.T) {
 				Zaehlernummer:      "0815",
 				Sparte:             sparte.STROM,
 				Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-				Zaehlertyp:         zaehlertyp.DREHSTROMZAEHLER,
+				Zaehlertyp:         internal.Ptr(zaehlertyp.DREHSTROMZAEHLER),
 				Tarifart:           internal.Ptr(tarifart.EINTARIF),
 				Zaehlerkonstante:   decimal.NullDecimal{},
 				Zaehlwerke: []com.Zaehlwerk{{

--- a/bo/zaehler.go
+++ b/bo/zaehler.go
@@ -1,6 +1,8 @@
 package bo
 
 import (
+	"time"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/fernschaltung"
 	"github.com/hochfrequenz/go-bo4e/enum/geraetemerkmal"
@@ -10,7 +12,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/zaehlerauspraegung"
 	"github.com/hochfrequenz/go-bo4e/enum/zaehlertyp"
 	"github.com/shopspring/decimal"
-	"time"
 )
 
 // Zaehler ist ein Modell für die Abbildung der Informationen zu einem Zähler
@@ -19,7 +20,7 @@ type Zaehler struct {
 	Zaehlernummer      string                                 `json:"zaehlernummer,omitempty" validate:"required,alphanum"` // Zaehlernummer ist eine Nummerierung des Zaehlers, vergeben durch den Messstellenbetreiber
 	Sparte             sparte.Sparte                          `json:"sparte,omitempty" validate:"required"`                 // Sparte ist eine Unterscheidungsmöglichkeit für die Sparte
 	Zaehlerauspraegung *zaehlerauspraegung.Zaehlerauspraegung `json:"zaehlerauspraegung,omitempty"`                         // Zaehlerauspraegung ist eine Spezifikation die Richtung des Zählers betreffend
-	Zaehlertyp         zaehlertyp.Zaehlertyp                  `json:"zaehlertyp,omitempty" validate:"required"`             // Zaehlertyp erlaubt eine Typisierung des Zählers
+	Zaehlertyp         *zaehlertyp.Zaehlertyp                 `json:"zaehlertyp,omitempty" validate:"required"`             // Zaehlertyp erlaubt eine Typisierung des Zählers
 	Tarifart           *tarifart.Tarifart                     `json:"tarifart,omitempty"`                                   // Tarifart erlaubt eine Spezifikation bezüglich unterstützter Tarifarten
 	Zaehlerkonstante   decimal.NullDecimal                    `json:"zaehlerkonstante,omitempty"`                           // Zaehlerkonstante ist die Zählerkonstante auf dem Zähler
 	EichungBis         time.Time                              `json:"eichungBis,omitempty"`                                 // EichungBis ist das exklusive Enddatum bis zu dem der Zähler geeicht ist

--- a/bo/zaehler_test.go
+++ b/bo/zaehler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/zaehlerauspraegung"
 	"github.com/hochfrequenz/go-bo4e/enum/zaehlertyp"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/testcase"
 	"github.com/shopspring/decimal"
 )
 
@@ -35,7 +36,7 @@ func Test_Zaehler_Deserialization(t *testing.T) {
 		Zaehlernummer:      "0815",
 		Sparte:             sparte.STROM,
 		Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-		Zaehlertyp:         zaehlertyp.DREHSTROMZAEHLER,
+		Zaehlertyp:         internal.Ptr(zaehlertyp.DREHSTROMZAEHLER),
 		Tarifart:           internal.Ptr(tarifart.EINTARIF),
 		//EichungBis:         time.Time{},
 		//LetzteEichung:      time.Time{},
@@ -82,7 +83,7 @@ func Test_Failed_ZaehlerValidation(t *testing.T) {
 				Zaehlernummer:      "0815",
 				Sparte:             sparte.STROM,
 				Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-				Zaehlertyp:         zaehlertyp.DREHSTROMZAEHLER,
+				Zaehlertyp:         internal.Ptr(zaehlertyp.DREHSTROMZAEHLER),
 				Tarifart:           internal.Ptr(tarifart.EINTARIF),
 				Zaehlerkonstante:   decimal.NewNullDecimal(decimal.NewFromFloat(17)),
 				Zaehlwerke:         []com.Zaehlwerk{},
@@ -106,7 +107,7 @@ func Test_Successful_Zaehler_Validation(t *testing.T) {
 			Zaehlernummer:      "08150",
 			Sparte:             sparte.STROM,
 			Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-			Zaehlertyp:         zaehlertyp.WECHSELSTROMZAEHLER,
+			Zaehlertyp:         internal.Ptr(zaehlertyp.WECHSELSTROMZAEHLER),
 			Tarifart:           internal.Ptr(tarifart.EINTARIF),
 			Zaehlerkonstante:   decimal.NullDecimal{Valid: false, Decimal: decimal.NewFromFloat(0)},
 			//EichungBis:         time.Time{},
@@ -154,4 +155,16 @@ func Test_Empty_Zaehler_Is_Creatable_Using_BoTyp(t *testing.T) {
 
 func Test_Serialized_Empty_Zaehler_Contains_No_Enum_Defaults(t *testing.T) {
 	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.ZAEHLER))
+}
+
+func TestZaehlerDeserializeExplicitNulls(t *testing.T) {
+	testcases := testcase.Map[testcase.JSONDeserializationSucceeds[bo.Zaehler]]{
+		"zaehlertyp": `{
+			"boTyp": "ZAEHLER",
+			"versionStruktur":"1",
+			"zaehlertyp": null
+		}`,
+	}
+
+	testcases.Run(t)
 }

--- a/market_communication/boney_comb_test.go
+++ b/market_communication/boney_comb_test.go
@@ -46,7 +46,7 @@ func Test_BOneyComb_DeSerialization(t *testing.T) {
 				Sparte:             sparte.STROM,
 				Zaehlernummer:      "1ASD23",
 				Zaehlerauspraegung: internal.Ptr(zaehlerauspraegung.EINRICHTUNGSZAEHLER),
-				Zaehlertyp:         zaehlertyp.DREHKOLBENZAEHLER,
+				Zaehlertyp:         internal.Ptr(zaehlertyp.DREHKOLBENZAEHLER),
 				Tarifart:           internal.Ptr(tarifart.EINTARIF),
 			},
 			&bo.Energiemenge{


### PR DESCRIPTION
Makes `Zaehler.Zaehlertyp` nullable, just as in [Zaehler.cs](https://github.com/Hochfrequenz/BO4E-dotnet/blob/main/BO4E/BO/Zaehler.cs).