### PR TITLE
DEV-68077: Make `COM.Hardware`/`Geraetetyp` nilable

### DIFF
--- a/com/hardware.go
+++ b/com/hardware.go
@@ -4,6 +4,6 @@ import "github.com/hochfrequenz/go-bo4e/enum/geraetetyp"
 
 // A Hardware is a billable device
 type Hardware struct {
-	GeraeteTyp  geraetetyp.Geraetetyp `json:"geraeteTyp,omitempty" validate:"required"`               // GeraeteTyp type of the hardware
-	Bezeichnung string                `json:"bezeichnung,omitempty" validate:"alphaunicode,required"` // Bezeichnung is a description
+	GeraeteTyp  *geraetetyp.Geraetetyp `json:"geraeteTyp,omitempty"`                                   // GeraeteTyp type of the hardware
+	Bezeichnung string                 `json:"bezeichnung,omitempty" validate:"alphaunicode,required"` // Bezeichnung is a description
 }


### PR DESCRIPTION
https://github.com/Hochfrequenz/BO4E-dotnet/pull/452
to be compatible with bo4e.net >=0.5.0