### PR TITLE
Add Missing Zeitreihentypen `SLS_TLS` and `SES_TES`

### DIFF
--- a/enum/zeitreihentyp/zeitreihentyp.go
+++ b/enum/zeitreihentyp/zeitreihentyp.go
@@ -9,11 +9,13 @@ package zeitreihentyp
 type Zeitreihentyp int
 
 const (
-	EGS Zeitreihentyp = iota + 1 // EGS ist eine Einspeisegangsumme
-	LGS                          // LGS ist eine Lastgangsumme
-	NZR                          // NZR ist eine Netzzeitreihe
-	SES                          // SES ist eine Standardeinspeiseprofilsumme
-	SLS                          // SLS ist eine Standardlastsumme
-	TES                          // TES ist eine tagesparameter-abhängige Einspeiseprofilsumme
-	TLS                          // TLS ist eine tagesparameter-abhängige Lastprofilsumme
+	EGS     Zeitreihentyp = iota + 1 // EGS ist eine Einspeisegangsumme
+	LGS                              // LGS ist eine Lastgangsumme
+	NZR                              // NZR ist eine Netzzeitreihe
+	SES                              // SES ist eine Standardeinspeiseprofilsumme
+	SLS                              // SLS ist eine Standardlastsumme
+	TES                              // TES ist eine tagesparameter-abhängige Einspeiseprofilsumme
+	TLS                              // TLS ist eine tagesparameter-abhängige Lastprofilsumme
+	SLS_TLS                          // SLS_TLS ist die gemeinsame Messung aus SLS und TLS
+	SES_TES                          // SES_TES ist die gemeinsame Messung aus SES und TES
 )

--- a/enum/zeitreihentyp/zeitreihentyp_jsonenums.go
+++ b/enum/zeitreihentyp/zeitreihentyp_jsonenums.go
@@ -9,23 +9,27 @@ import (
 
 var (
 	_ZeitreihentypNameToValue = map[string]Zeitreihentyp{
-		"EGS": EGS,
-		"LGS": LGS,
-		"NZR": NZR,
-		"SES": SES,
-		"SLS": SLS,
-		"TES": TES,
-		"TLS": TLS,
+		"EGS":     EGS,
+		"LGS":     LGS,
+		"NZR":     NZR,
+		"SES":     SES,
+		"SLS":     SLS,
+		"TES":     TES,
+		"TLS":     TLS,
+		"SLS_TLS": SLS_TLS,
+		"SES_TES": SES_TES,
 	}
 
 	_ZeitreihentypValueToName = map[Zeitreihentyp]string{
-		EGS: "EGS",
-		LGS: "LGS",
-		NZR: "NZR",
-		SES: "SES",
-		SLS: "SLS",
-		TES: "TES",
-		TLS: "TLS",
+		EGS:     "EGS",
+		LGS:     "LGS",
+		NZR:     "NZR",
+		SES:     "SES",
+		SLS:     "SLS",
+		TES:     "TES",
+		TLS:     "TLS",
+		SLS_TLS: "SLS_TLS",
+		SES_TES: "SES_TES",
 	}
 )
 
@@ -33,13 +37,15 @@ func init() {
 	var v Zeitreihentyp
 	if _, ok := interface{}(v).(fmt.Stringer); ok {
 		_ZeitreihentypNameToValue = map[string]Zeitreihentyp{
-			interface{}(EGS).(fmt.Stringer).String(): EGS,
-			interface{}(LGS).(fmt.Stringer).String(): LGS,
-			interface{}(NZR).(fmt.Stringer).String(): NZR,
-			interface{}(SES).(fmt.Stringer).String(): SES,
-			interface{}(SLS).(fmt.Stringer).String(): SLS,
-			interface{}(TES).(fmt.Stringer).String(): TES,
-			interface{}(TLS).(fmt.Stringer).String(): TLS,
+			interface{}(EGS).(fmt.Stringer).String():     EGS,
+			interface{}(LGS).(fmt.Stringer).String():     LGS,
+			interface{}(NZR).(fmt.Stringer).String():     NZR,
+			interface{}(SES).(fmt.Stringer).String():     SES,
+			interface{}(SLS).(fmt.Stringer).String():     SLS,
+			interface{}(TES).(fmt.Stringer).String():     TES,
+			interface{}(TLS).(fmt.Stringer).String():     TLS,
+			interface{}(SLS_TLS).(fmt.Stringer).String(): SLS_TLS,
+			interface{}(SES_TES).(fmt.Stringer).String(): SES_TES,
 		}
 	}
 }

--- a/enum/zeitreihentyp/zeitreihentyp_string.go
+++ b/enum/zeitreihentyp/zeitreihentyp_string.go
@@ -15,11 +15,13 @@ func _() {
 	_ = x[SLS-5]
 	_ = x[TES-6]
 	_ = x[TLS-7]
+	_ = x[SLS_TLS-8]
+	_ = x[SES_TES-9]
 }
 
-const _Zeitreihentyp_name = "EGSLGSNZRSESSLSTESTLS"
+const _Zeitreihentyp_name = "EGSLGSNZRSESSLSTESTLSSLS_TLSSES_TES"
 
-var _Zeitreihentyp_index = [...]uint8{0, 3, 6, 9, 12, 15, 18, 21}
+var _Zeitreihentyp_index = [...]uint8{0, 3, 6, 9, 12, 15, 18, 21, 28, 35}
 
 func (i Zeitreihentyp) String() string {
 	i -= 1


### PR DESCRIPTION
DEV-70769
https://github.com/Hochfrequenz/BO4E-dotnet/blob/c9038e113d5f5342c20132a040f9934e35a993dd/BO4E/ENUM/Zeitreihentyp.cs#L43