### PR TITLE
Fix: Messwerterfassung is `FERNAUSLESBAR`, not `FERN_AUSLESBAR`

### DIFF
--- a/enum/messwerterfassung/messwerterfassung.go
+++ b/enum/messwerterfassung/messwerterfassung.go
@@ -8,8 +8,8 @@ package messwerterfassung
 type Messwerterfassung int
 
 const (
-	// FERN_AUSLESBAR describes automatic meter readings (EDIFACT AMR)
-	FERN_AUSLESBAR Messwerterfassung = iota + 1
+	// FERNAUSLESBAR describes automatic meter readings (EDIFACT AMR)
+	FERNAUSLESBAR Messwerterfassung = iota + 1
 	// MANUELL_AUSGELESENE describes manual meter readings (EDIFACT MMR)
 	MANUELL_AUSGELESENE
 )

--- a/enum/messwerterfassung/messwerterfassung_jsonenums.go
+++ b/enum/messwerterfassung/messwerterfassung_jsonenums.go
@@ -9,12 +9,12 @@ import (
 
 var (
 	_MesswerterfassungNameToValue = map[string]Messwerterfassung{
-		"FERN_AUSLESBAR":      FERN_AUSLESBAR,
+		"FERNAUSLESBAR":       FERNAUSLESBAR,
 		"MANUELL_AUSGELESENE": MANUELL_AUSGELESENE,
 	}
 
 	_MesswerterfassungValueToName = map[Messwerterfassung]string{
-		FERN_AUSLESBAR:      "FERN_AUSLESBAR",
+		FERNAUSLESBAR:       "FERNAUSLESBAR",
 		MANUELL_AUSGELESENE: "MANUELL_AUSGELESENE",
 	}
 )
@@ -23,7 +23,7 @@ func init() {
 	var v Messwerterfassung
 	if _, ok := interface{}(v).(fmt.Stringer); ok {
 		_MesswerterfassungNameToValue = map[string]Messwerterfassung{
-			interface{}(FERN_AUSLESBAR).(fmt.Stringer).String():      FERN_AUSLESBAR,
+			interface{}(FERNAUSLESBAR).(fmt.Stringer).String():       FERNAUSLESBAR,
 			interface{}(MANUELL_AUSGELESENE).(fmt.Stringer).String(): MANUELL_AUSGELESENE,
 		}
 	}

--- a/enum/messwerterfassung/messwerterfassung_string.go
+++ b/enum/messwerterfassung/messwerterfassung_string.go
@@ -8,13 +8,13 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[FERN_AUSLESBAR-1]
+	_ = x[FERNAUSLESBAR-1]
 	_ = x[MANUELL_AUSGELESENE-2]
 }
 
-const _Messwerterfassung_name = "FERN_AUSLESBARMANUELL_AUSGELESENE"
+const _Messwerterfassung_name = "FERNAUSLESBARMANUELL_AUSGELESENE"
 
-var _Messwerterfassung_index = [...]uint8{0, 14, 33}
+var _Messwerterfassung_index = [...]uint8{0, 13, 32}
 
 func (i Messwerterfassung) String() string {
 	i -= 1


### PR DESCRIPTION
in bo4e.net since at least 4 years: https://github.com/Hochfrequenz/BO4E-dotnet/blob/688b48c2a9a9d4454e7c77e751e947e39ef48525/BO4E/ENUM/Messwerterfassung.cs#L10
DEV-70766
