### PR TITLE
DEV-67855 Enhance unmarshalling of BusinessObjectSlice.

### DIFF
--- a/bo/businessobject_slice_test.go
+++ b/bo/businessobject_slice_test.go
@@ -88,3 +88,37 @@ func Test_Slice_Deserialization_Fails_For_Unimplemented_BoTyps(t *testing.T) {
 	err := json.Unmarshal([]byte(jsonWithUnimplementedBoTyp), &deserializedBoneyComb)
 	then.AssertThat(t, err, is.Not(is.Nil()))
 }
+
+func TestBusinessObjectSliceUnmarshalErrors(t *testing.T) {
+	rawJSON := `
+	[
+		{
+			"boTyp": "foo"
+		},
+		{
+			"boTyp": "PREISBLATT",
+			"Herausgeber": true,
+			"Gueltigkeit": "always"
+		},
+		{
+			"boTyp": 5000
+		}
+	]
+	`
+
+	var boSlice bo.BusinessObjectSlice
+
+	err := json.Unmarshal([]byte(rawJSON), &boSlice)
+
+	unwrapper, ok := err.(interface{ Unwrap() []error })
+	if !ok {
+		t.Errorf("expected error to provide wrapped errors, got %+v (%T)", err, err)
+	}
+
+	errs := unwrapper.Unwrap()
+	if len(errs) != 3 {
+		t.Errorf("expected 3 errors, got %+v (%d errors)", errs, len(errs))
+	}
+
+	// We do not check the types of errors as there's no reliable error API yet.
+}


### PR DESCRIPTION
Change `BusinessObjectSlice.Unmarshal` to try to unmarshal every `Stammdaten` entry first, then gathering all the errors that occured and returning them as a joined error. Before, the first error "won" and was returned. We get more insights into problematic payloads.

By accident is a workaround for [Go issue 68750](https://github.com/golang/go/issues/68750) as well.