### PR TITLE
Fix tests that deserialize BOneyComb.

### DIFF
--- a/bo/businessobject_slice_test.go
+++ b/bo/businessobject_slice_test.go
@@ -76,14 +76,14 @@ func Test_Successful_Slice_Deserialization(t *testing.T) {
 }
 
 func Test_Slice_Deserialization_Fails_For_Invalid_BoTyps(t *testing.T) {
-	jsonWithInvalidBoTyp := "[{\"boTyp\":\"foo\"}]" // foo is not a valid boTyp => deserialization should fail
+	jsonWithInvalidBoTyp := `{"stammdaten": [{"boTyp":"foo"}]}` // foo is not a valid boTyp => deserialization should fail
 	var deserializedBoneyComb market_communication.BOneyComb
 	err := json.Unmarshal([]byte(jsonWithInvalidBoTyp), &deserializedBoneyComb)
 	then.AssertThat(t, err, is.Not(is.Nil()))
 }
 
 func Test_Slice_Deserialization_Fails_For_Unimplemented_BoTyps(t *testing.T) {
-	jsonWithUnimplementedBoTyp := "[{\"boTyp\":\"PREISBLATTUMLAGEN\"}]" // PREISBLATTUMLAGEN is not (yet) an implemented boTyp => deserialization should fail
+	jsonWithUnimplementedBoTyp := `{"stammdaten": [{"boTyp":"PREISBLATTUMLAGEN"}]}` // PREISBLATTUMLAGEN is not (yet) an implemented boTyp => deserialization should fail
 	var deserializedBoneyComb market_communication.BOneyComb
 	err := json.Unmarshal([]byte(jsonWithUnimplementedBoTyp), &deserializedBoneyComb)
 	then.AssertThat(t, err, is.Not(is.Nil()))


### PR DESCRIPTION
The `bo` package tests `Test_Slice_Deserialization_Fails_For_Invalid_BoTyps` and `Test_Slice_Deserialization_Fails_For_Unimplemented_BoTyps` were broken - they succeeded, but for the wrong reasons. Their raw JSON contains an array, but is marshalled into `market_communication.BOneyComb` which does not accept arrays. Unlike the comments in the tests suggested, the actual errors for both are `json: cannot unmarshal array into Go value of type market_communication.BOneyComb`.

This PR fixes that (I checked the errors, they're correct now).

In addition, formatting of the raw JSON is changed to be slightly more readable.