### PR TITLE
Remove GetDefaultJsonTags()

### DIFF
--- a/bo/angebot.go
+++ b/bo/angebot.go
@@ -1,9 +1,10 @@
 package bo
 
 import (
+	"time"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
-	"time"
 )
 
 // THIS IS STILL WIP - missing Angebotsvariante, Angebotsteil, Angebotsstatus etc.
@@ -23,8 +24,4 @@ type Angebot struct {
 	UnterzeichnerAngebotsnehmer *Ansprechpartner       `json:"unterzeichnerAngebotsnehmer,omitempty"`        // Link auf die Person, die als Angebotsnehmer das Angebot angenommen hat.
 	UnterzeichnerAngebotsgeber  *Ansprechpartner       `json:"unterzeichnerAngebotsgeber,omitempty"`         // Link auf die Person, die als Angebotsgeber das Angebot ausgestellt hat.
 	Varianten                   []com.Angebotsvariante `json:"varianten,omitempty"`                          // Eine oder mehrere Varianten des Angebots mit den Angebotsteilen. Ein Angebot besteht mindestens aus einer Variante.
-}
-
-func (_ Angebot) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }

--- a/bo/ansprechpartner.go
+++ b/bo/ansprechpartner.go
@@ -25,7 +25,3 @@ type Ansprechpartner struct {
 	// https://github.com/Hochfrequenz/bo4e-modification-proposals/blob/master/markdown/ansprechpartner_rufnummern.md
 
 }
-
-func (_ Ansprechpartner) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/avis.go
+++ b/bo/avis.go
@@ -15,10 +15,6 @@ type Avis struct {
 	ZuZahlen       com.Betrag         `json:"zuZahlen,omitempty" validate:"required"`         // Summenbetrag
 }
 
-func (_ Avis) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}
-
 // AvisStructLevelValidation combines all the single validators
 func AvisStructLevelValidation(sl validator.StructLevel) {
 	AvisStructLevelValidationZuZahlen(sl)

--- a/bo/bilanzierung.go
+++ b/bo/bilanzierung.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"regexp"
+	"time"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/enum/abwicklungsmodell"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
-	"regexp"
-	"time"
 
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/aggregationsverantwortung"
@@ -17,7 +18,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/prognosegrundlage"
 	"github.com/hochfrequenz/go-bo4e/enum/wahlrechtprognosegrundlage"
 	"github.com/hochfrequenz/go-bo4e/enum/zeitreihentyp"
-	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 	"github.com/shopspring/decimal"
 )
 
@@ -46,12 +46,6 @@ type Bilanzierung struct {
 	MarktlokationsId           *string                                                `json:"marktlokationsId,omitempty" validate:"omitempty,maloid"` // MarktlokationsId referenziert eine Marktlokation
 	Abwicklungsmodell          *abwicklungsmodell.Abwicklungsmodell                   `json:"abwicklungsmodell,omitempty"`                            // Abwicklungsmodell beschreibt wo die Bilanzierung statt findet
 
-}
-
-func (bila Bilanzierung) GetDefaultJsonTags() []string {
-	// We know we pass a struct here so ignore the error.
-	fields, _ := jsonfieldnames.Extract(bila)
-	return fields
 }
 
 func (bila *Bilanzierung) UnmarshalJSON(bytes []byte) (err error) {

--- a/bo/businessobject.go
+++ b/bo/businessobject.go
@@ -12,8 +12,6 @@ type BusinessObject interface {
 	GetBoTyp() botyp.BOTyp
 	// GetVersionStruktur returns the Geschaeftsobjekt.VersionStruktur
 	GetVersionStruktur() string
-	// GetDefaultJsonTags returns an array of string that represent the json tags that are (by default) used by this business object
-	GetDefaultJsonTags() []string
 }
 
 // Geschaeftsobjekt is the common base struct of all Business Objects

--- a/bo/einspeisung.go
+++ b/bo/einspeisung.go
@@ -17,7 +17,3 @@ type Einspeisung struct {
 	Landescode              *landescode.Landescode                           `json:"landescode,omitempty"`              // Land der Förderung
 	FernsteuerbarkeitStatus *fernsteuerbarkeitstatus.FernsteuerbarkeitStatus `json:"fernsteuerbarkeitStatus,omitempty"` // Status der Fernsteuerbarkeit einer Marktlokation
 }
-
-func (_ Einspeisung) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/energiemenge.go
+++ b/bo/energiemenge.go
@@ -12,7 +12,3 @@ type Energiemenge struct {
 	LokationsTyp *lokationstyp.Lokationstyp `json:"lokationsTyp,omitempty" example:"MELO" validate:"required"`                                                    // LokationsTyp is the type of the location in LokationsId
 	Verbrauch    []com.Verbrauch            `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Verbrauch are consumption data
 }
-
-func (_ Energiemenge) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/geschaeftspartner.go
+++ b/bo/geschaeftspartner.go
@@ -30,7 +30,3 @@ type Geschaeftspartner struct {
 	Erreichbarkeit                   *com.Erreichbarkeit                                             `json:"erreichbarkeit,omitempty"`
 	GruendeDerPrivilegierungNachEnFG []grundderprivilegierungnachenfg.GrundDerPrivilegierungNachEnFG `json:"gruendeDerPrivilegierungNachEnFG,omitempty"` //Erreichbarkeit ist die Erreichbarkeit des Geschäftspartners
 }
-
-func (_ Geschaeftspartner) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/handelsunstimmigkeit.go
+++ b/bo/handelsunstimmigkeit.go
@@ -21,7 +21,3 @@ type Handelsunstimmigkeit struct {
 	// Betrag is the requested sum amount (optional).
 	Betrag *com.Betrag `json:"zuZahlen,omitempty"`
 }
-
-func (_ Handelsunstimmigkeit) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/lastgang.go
+++ b/bo/lastgang.go
@@ -18,7 +18,3 @@ type Lastgang struct {
 	Obiskennzahl string                      `json:"obiskennzahl,omitempty" example:"1-0:1.8.1"`                                                                   // Obiskennzahl ist die genormte OBIS-Kennzahl zur Kennzeichnung der Messgröße
 	Werte        []com.Zeitreihenwert        `json:"energieverbrauch,omitempty" validate:"required,min=1"`                                                         // Werte sind die im Lastgang enthaltenen Messwerte.
 }
-
-func (_ Lastgang) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/marktlokation.go
+++ b/bo/marktlokation.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/netzebene"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/verbrauchsart"
-	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 )
 
 // Marktlokation contains information about a market location aka "MaLo"
@@ -75,12 +74,6 @@ func (malo Marktlokation) MarshalJSON() (bytes []byte, err error) {
 		return
 	}
 	return unmappeddatamarshaller.HandleUnmappedDataPropertyMarshalling(byteArr)
-}
-
-func (malo Marktlokation) GetDefaultJsonTags() []string {
-	// We know we pass a struct here so ignore the error.
-	fields, _ := jsonfieldnames.Extract(malo)
-	return fields
 }
 
 var elevenDigitsRegex = regexp.MustCompile(`^[1-9]\d{10}$`)

--- a/bo/marktteilnehmer.go
+++ b/bo/marktteilnehmer.go
@@ -2,9 +2,9 @@ package bo
 
 import (
 	"encoding/json"
+
 	"github.com/hochfrequenz/go-bo4e/enum/marktrolle"
 	"github.com/hochfrequenz/go-bo4e/enum/rollencodetyp"
-	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 )
 
@@ -16,12 +16,6 @@ type Marktteilnehmer struct {
 	Rollencodetyp    rollencodetyp.Rollencodetyp `json:"rollencodetyp,omitempty" validate:"required"`                          // Rollencodetyp gibt den Typ des Codes an/Vergabestelle. Details siehe ENUM Rollencodetyp
 	Makoadresse      string                      `json:"makoadresse,omitempty" validate:"omitempty"`                           // Makoadresse ist die 1:1-Kommunikationsadresse des Marktteilnehmers. Diese wird in der Marktkommunikation verwendet.
 	Ansprechpartner  *Ansprechpartner            `json:"ansprechpartner,omitempty" validate:"omitempty"`                       // Ansprechpartner ist ein Kontakt zur bilateralen Klärung
-}
-
-func (marktteilnehmer Marktteilnehmer) GetDefaultJsonTags() []string {
-	// We know we pass a struct here so ignore the error.
-	fields, _ := jsonfieldnames.Extract(marktteilnehmer)
-	return fields
 }
 
 func (marktteilnehmer *Marktteilnehmer) UnmarshalJSON(bytes []byte) (err error) {

--- a/bo/messlokation.go
+++ b/bo/messlokation.go
@@ -2,12 +2,12 @@ package bo
 
 import (
 	"encoding/json"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/gasqualitaet"
 	"github.com/hochfrequenz/go-bo4e/enum/netzebene"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
-	"github.com/hochfrequenz/go-bo4e/internal/jsonfieldnames"
 	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 )
 
@@ -44,12 +44,6 @@ func XorStructLevelMesslokationValidation(sl validator.StructLevel) {
 	if numberOfAdresses > 1 {
 		sl.ReportError(Messlokation{}.Messadresse, "", "", "onlyOneAddressType", "")
 	}
-}
-
-func (melo Messlokation) GetDefaultJsonTags() []string {
-	// We know we pass a struct here so ignore the error.
-	fields, _ := jsonfieldnames.Extract(melo)
-	return fields
 }
 
 func (melo *Messlokation) UnmarshalJSON(bytes []byte) (err error) {

--- a/bo/netzlokation.go
+++ b/bo/netzlokation.go
@@ -2,12 +2,13 @@ package bo
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/marktrolle"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/internal"
-	"regexp"
-	"strconv"
 )
 
 // NeLo is short for Netzlokation.
@@ -67,8 +68,4 @@ type Netzlokation struct {
 	Konfigurationsprodukte     []com.Konfigurationsprodukt `json:"konfigurationsprodukte,omitempty"`     // Produkt-Daten der Netzlokation
 	EigenschaftMSBLokation     *marktrolle.Marktrolle      `json:"eigenschaftMSBLokation,omitempty"`     // Eigenschaft des Messstellenbetreibers an der Lokation
 	LokationsbuendelObjektcode *string                     `json:"lokationsbuendelObjektcode,omitempty"` // Lokationsbuendel-Code, der die Funktion dieses BOs an der Lokationsbuendelstruktur beschreibt.
-}
-
-func (_ Netzlokation) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }

--- a/bo/netznutzungsrechnung.go
+++ b/bo/netznutzungsrechnung.go
@@ -18,7 +18,3 @@ type Netznutzungsrechnung struct {
 	Simuliert            bool                          `json:"simuliert"`                                                                // Simuliert ist ein Kennzeichen, ob es sich um eine simulierte Rechnung, z.B. zur Rechnungsprüfung handelt.
 	LokationsId          string                        `json:"lokationsId,omitempty" validate:"omitempty,alphanum,max=33,min=11"`        // LokationsId ist die Markt- oder Messlokations-Identifikation (als Malo/Melo-Id) der Lokation, auf die sich die Rechnung bezieht.
 }
-
-func (_ Netznutzungsrechnung) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/preisblatt.go
+++ b/bo/preisblatt.go
@@ -19,7 +19,3 @@ type Preisblatt struct {
 	Gueltigkeit     com.Zeitraum             `json:"gueltigkeit" validate:"required"`           // Der Zeitraum für den der Preis festgelegt ist
 	Preispositionen []com.Preisposition      `json:"preispositionen" validate:"required"`       // Die einzelnen Positionen, die mit dem Preisblatt abgerechnet werden können. Z.B. Arbeitspreis, Grundpreis etc
 }
-
-func (_ Preisblatt) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/rechnung.go
+++ b/bo/rechnung.go
@@ -1,8 +1,9 @@
 package bo
 
 import (
-	"github.com/hochfrequenz/go-bo4e/enum/sonderrechnungsart"
 	"time"
+
+	"github.com/hochfrequenz/go-bo4e/enum/sonderrechnungsart"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/hochfrequenz/go-bo4e/com"
@@ -38,10 +39,6 @@ type Rechnung struct {
 	Vorauszahlungen         []com.Vorauszahlung                    `json:"vorauszahlungen,omitempty"`                               // Vorauszahlungen sind evtl. vorausgezahlte Beträge, z.B. Abschläge. Angabe als Bruttowert
 	Sonderrechnungsart      *sonderrechnungsart.Sonderrechnungsart `json:"sonderrechnungsart,omitempty"`
 	Buchungsdatum           time.Time                              `json:"buchungsdatum,omitempty"` // Buchungsdatum ist das Datum, zu dem die Zahlung fällig ist
-}
-
-func (_ Rechnung) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }
 
 // RechnungStructLevelValidation combines all the single validators

--- a/bo/reklamation.go
+++ b/bo/reklamation.go
@@ -17,7 +17,3 @@ type Reklamation struct {
 	ReklamationsgrundBemerkung string                              `json:"reklamationsgrundBemerkung,omitempty" validate:"omitempty"`                                                    // ReklamationsgrundBemerkung ist ein Freitext für eine weitere Beschreibung des Reklamationsgrunds
 	Positionsnummer            int                                 `json:"positionsnummer,omitempty" validate:"omitempty"`                                                               // Positionsnummer ist eine fortlaufende Nummer für die Position
 }
-
-func (_ Reklamation) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/statusbericht.go
+++ b/bo/statusbericht.go
@@ -16,7 +16,3 @@ type Statusbericht struct {
 	DatumPruefung   time.Time                   `json:"datumPruefung"`                         // Pruefdatum (wann wurde der Pruefgegenstand geprüft)
 	Fehler          *com.Fehler                 `json:"fehler,omitempty"`                      // Liste der Fehler
 }
-
-func (s Statusbericht) GetDefaultJsonTags() []string {
-	panic("implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/steuerbareressorce.go
+++ b/bo/steuerbareressorce.go
@@ -2,10 +2,11 @@ package bo
 
 import (
 	"fmt"
-	"github.com/hochfrequenz/go-bo4e/enum/steuerkanalsleistungsbeschreibung"
-	"github.com/hochfrequenz/go-bo4e/internal"
 	"regexp"
 	"strconv"
+
+	"github.com/hochfrequenz/go-bo4e/enum/steuerkanalsleistungsbeschreibung"
+	"github.com/hochfrequenz/go-bo4e/internal"
 )
 
 // SR-ID is short for Steuerbare Ressource-ID
@@ -55,8 +56,4 @@ type SteuerbareRessource struct {
 	SteuerbareRessourceId             string                                                               `json:"steuerbareRessourceId" validate:"required"` // Identifikationsnummer einer SteuerbareRessource
 	SteuerkanalsLeistungsbeschreibung *steuerkanalsleistungsbeschreibung.Steuerkanalsleistungsbeschreibung `json:"steuerkanalsLeistungsbeschreibung"`         // Leistungsbeschreibung des Steuerkanals
 	ZugeordnetMSBCodeNr               *string                                                              `json:"zugeordnetMSBCodeNr"`                       // Angabe des Messstellenbetreibers, der der Steuerbaren Ressource zugeordnet ist
-}
-
-func (_ SteuerbareRessource) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }

--- a/bo/summenzeitreihe.go
+++ b/bo/summenzeitreihe.go
@@ -4,7 +4,3 @@ package bo
 type Summenzeitreihe struct {
 	Geschaeftsobjekt
 }
-
-func (_ Summenzeitreihe) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/technischeressource.go
+++ b/bo/technischeressource.go
@@ -2,6 +2,9 @@ package bo
 
 import (
 	"fmt"
+	"regexp"
+	"strconv"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/emobilitaetsart"
 	"github.com/hochfrequenz/go-bo4e/enum/erzeugungsart"
@@ -10,8 +13,6 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/technischeressourceverbrauchsart"
 	"github.com/hochfrequenz/go-bo4e/enum/waermenutzung"
 	"github.com/hochfrequenz/go-bo4e/internal"
-	"regexp"
-	"strconv"
 )
 
 // TR-ID is short for Technische Ressource-ID
@@ -71,8 +72,4 @@ type TechnischeRessource struct {
 	EMobilitaetsart                  *emobilitaetsart.EMobilitaetsart                                   `json:"emobilitaetsart" example:"CAV+Z87"`                                                                                     //Art der E-Mobilität  Das Segment dient dazu, im Falle der E-Mobilität eine genauere Angabe über die Art der E-Mobilität zu definieren
 	Erzeugungsart                    *erzeugungsart.Erzeugungsart                                       `json:"erzeugungsart" example:"CAV+ZF5"`                                                                                       //Art der Erzeugung der Energie
 	Speicherart                      *speicherart.Speicherart                                           `json:"speicherart" example:"CAV+ZF7"`                                                                                         //Art der speicher. Details <see cref="ENUM.Speicherart" />
-}
-
-func (_ TechnischeRessource) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }

--- a/bo/tranche.go
+++ b/bo/tranche.go
@@ -12,7 +12,3 @@ type Tranche struct {
 	Aufteilungsmenge decimal.NullDecimal `json:"aufteilungsmenge" validate:"required"` // Prozentualer Anteil der Tranche an der erzeugenden Marktlokation in Prozent mit 2 Nachkommastellen
 	ObisKennzahl     *string             `json:"obisKennzahl" validate:"required"`     // Die OBIS-Kennzahl für die Tranche, die festlegt, welche auf die gemessene Größe mit dem Stand gemeldet wird.
 }
-
-func (_ Tranche) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/vertrag.go
+++ b/bo/vertrag.go
@@ -1,12 +1,13 @@
 package bo
 
 import (
+	"time"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/sparte"
 	"github.com/hochfrequenz/go-bo4e/enum/vertragsart"
 	"github.com/hochfrequenz/go-bo4e/enum/vertragsstatus"
 	"github.com/shopspring/decimal"
-	"time"
 )
 
 // Vertrag ist ein Modell für die Abbildung von Vertragsbeziehungen. Das Objekt dient dazu, alle Arten von Verträgen, die in der Energiewirtschaft Verwendung finden, abzubilden.
@@ -27,8 +28,4 @@ type Vertrag struct {
 	Vertragskonditionen *com.Vertragskonditionen `json:"vertragskonditionen,omitempty"`                                     // Vertragskonditionen ist eine Festlegungen zu Laufzeiten und Kündigungsfristen
 	Vertragsteile       []com.Vertragsteil       `json:"vertragsteile,omitempty" validate:"required,min=1"`                 // Vertragsteile sind die Vertragsteile, die dazu verwendet werden, eine vertragliche Leistung in Bezug zu einer Lokation (Markt- oder Messlokation) festzulegen.
 	Gemeinderabatt      decimal.NullDecimal      `json:"gemeinderabatt" validate:"required"`                                // Gemeinderabatt für EDIFACT mapping.
-}
-
-func (_ Vertrag) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }

--- a/bo/zaehler.go
+++ b/bo/zaehler.go
@@ -33,7 +33,3 @@ type Zaehler struct {
 	Fernschaltung     *fernschaltung.Fernschaltung         `json:"fernschaltung,omitempty"`     // Fernschaltung is set to VORHANDEN if there is a fernschaltung
 	Messwerterfassung *messwerterfassung.Messwerterfassung `json:"messwerterfassung,omitempty"` // Messwerterfassung describes if meter readings have to happen manually
 }
-
-func (_ Zaehler) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
-}

--- a/bo/zaehlzeitdefinition.go
+++ b/bo/zaehlzeitdefinition.go
@@ -1,9 +1,10 @@
 package bo
 
 import (
+	"time"
+
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/definitionennotwendigkeit"
-	"time"
 )
 
 // Zaehlzeitdefinition en nutzt der NB bzw. LF  für die Tarifierung von Werten.
@@ -18,8 +19,4 @@ type Zaehlzeitdefinition struct {
 	Zaehlzeiten            []com.Zaehlzeit                                      `json:"zaehlzeiten,omitempty"`
 	Zaehlzeitregister      []com.Zaehlzeitregister                              `json:"zaehlzeitregister,omitempty"`
 	AusgerollteZaehlzeiten []com.AusgerollteZaehlzeit                           `json:"ausgerollteZaehlzeiten,omitempty"`
-}
-
-func (_ Zaehlzeitdefinition) GetDefaultJsonTags() []string {
-	panic("todo: implement me") // this is needed for (un)marshaling of non-default/unknown json fields
 }


### PR DESCRIPTION
In #77, the method `GetDefaultJsonTags() []string` was added to the `BusinessObject` interface, with mostly stub implementations added to all types that are supposed to implement said interface. It was meant to back the extension data mechanism, which allows entities to carry arbitrary data in addition to their fixed fields. This was later changed to a generic implementation (see `internal/fieldnames#Extract`).

This PR removes `GetDefaultJsonTags` everywhere. It's not used by the module itself, it just provides it. Users can't really rely on it as most implementations just panic. Whether or not a specific method panics is not documented, so you'd have to look into the code to tell. Also I looked into a codebase which makes heavy use of go-bo4e, with `GetDefaultJsonTags` nowhere to be found.

Technically this is a breaking change, but I suspect nearly all users will not be affected and we still didn't reach `1.0.0`. :-)