### PR TITLE
fix: add backwards-compat UnmarshalJSON for Reklamation.Positionsnummer

### DIFF
--- a/bo/reklamation.go
+++ b/bo/reklamation.go
@@ -1,6 +1,8 @@
 package bo
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/hochfrequenz/go-bo4e/com"
@@ -20,4 +22,32 @@ type Reklamation struct {
 	// Positionsnummer: Aus der ORDERS gemappte Positionsnummer der Anfrage
 	Positionsnummer          string     `json:"positionsnummer,omitempty" validate:"omitempty"`
 	ZeitpunktFuerWertanfrage *time.Time `json:"zeitpunktFuerWertanfrage,omitempty" validate:"omitempty"` // ZeitpunktFuerWertanfrage gibt den com.Zeitpunkt an, zu dem die Wertanfrage erfolgt ist.
+}
+
+// UnmarshalJSON supports deserializing both string and integer Positionsnummer for backwards compatibility.
+func (r *Reklamation) UnmarshalJSON(data []byte) error {
+	type Alias Reklamation
+	aux := &struct {
+		*Alias
+		RawPositionsnummer json.RawMessage `json:"positionsnummer,omitempty"`
+	}{
+		Alias: (*Alias)(r),
+	}
+	if err := json.Unmarshal(data, aux); err != nil {
+		return err
+	}
+	if len(aux.RawPositionsnummer) > 0 {
+		var s string
+		if err := json.Unmarshal(aux.RawPositionsnummer, &s); err == nil {
+			r.Positionsnummer = s
+		} else {
+			var n json.Number
+			if err2 := json.Unmarshal(aux.RawPositionsnummer, &n); err2 == nil {
+				r.Positionsnummer = n.String()
+			} else {
+				return fmt.Errorf("positionsnummer must be a string or number, got %s", string(aux.RawPositionsnummer))
+			}
+		}
+	}
+	return nil
 }

--- a/bo/reklamation_test.go
+++ b/bo/reklamation_test.go
@@ -106,3 +106,12 @@ func Test_Empty_Reklamation_Is_Creatable_Using_BoTyp(t *testing.T) {
 func Test_Serialized_Empty_Reklamation_Contains_No_Enum_Defaults(t *testing.T) {
 	assertDoesNotSerializeDefaultEnums(t, bo.NewBusinessObject(botyp.REKLAMATION))
 }
+
+// Test_Reklamation_IntegerPositionsnummer_BackwardsCompat ensures integer positionsnummer values deserialize correctly
+func Test_Reklamation_IntegerPositionsnummer_BackwardsCompat(t *testing.T) {
+	jsonWithIntPositionsnummer := `{"boTyp":"REKLAMATION","versionStruktur":"1","lokationsId":"12345678910","lokationsTyp":"MALO","reklamationsgrund":"WERTE_FEHLEN","obisKennzahl":"1-0:1.8.0","zeitraumMesswertanfrage":{"startzeitpunkt":"2021-12-31T22:00:00Z"},"positionsnummer":42}`
+	var reklamation bo.Reklamation
+	err := json.Unmarshal([]byte(jsonWithIntPositionsnummer), &reklamation)
+	then.AssertThat(t, err, is.Nil())
+	then.AssertThat(t, reklamation.Positionsnummer, is.EqualTo("42"))
+}


### PR DESCRIPTION
Anfrage received a custom UnmarshalJSON to handle both string and integer Positionsnummer for backwards compatibility, but Reklamation was missed. This adds the same treatment to prevent breaking existing serialized data.