### PR TITLE
fix: add missing docstrings to Unternehmensart enum values

### DIFF
--- a/enum/unternehmensart/unternehmensart.go
+++ b/enum/unternehmensart/unternehmensart.go
@@ -7,11 +7,18 @@ package unternehmensart
 type Unternehmensart int
 
 const (
+	// LIEFERANT: Energielieferant
 	LIEFERANT Unternehmensart = iota + 1
+	// NETZBETREIBER: Verteilnetzbetreiber
 	NETZBETREIBER
+	// MESSSTELLENBETREIBER: Messstellenbetreiber
 	MESSSTELLENBETREIBER
+	// UEBERTRAGUNGSNETZBETREIBER: Übertragungsnetzbetreiber
 	UEBERTRAGUNGSNETZBETREIBER
+	// BILANZKOORDINATOR: Bilanzkoordinator
 	BILANZKOORDINATOR
+	// BILANZKREISVERANTWORTLICHER: Bilanzkreisverantwortlicher
 	BILANZKREISVERANTWORTLICHER
+	// ENERGIESERVICEANBIETER: Energiedienstleistungsunternehmen
 	ENERGIESERVICEANBIETER
 )


### PR DESCRIPTION
Every other enum in this project has per-value docstrings (e.g. marktrolle, anrede, fernschaltung, lokationsbuendelstrukturvorhanden). Unternehmensart was added without them, breaking the project convention and making the enum values harder to understand for consumers of the library.