### PR TITLE
fix: add Z31/Z39 EDIFACT aliases to LokationsbuendelstrukturVorhanden; remove skipList

### DIFF
--- a/enum/lokationsbuendelstrukturvorhanden/lokationsbuendelstrukturvorhanden_jsonenums.go
+++ b/enum/lokationsbuendelstrukturvorhanden/lokationsbuendelstrukturvorhanden_jsonenums.go
@@ -11,6 +11,8 @@ var (
 	_LokationsbuendelstrukturVorhandenNameToValue = map[string]LokationsbuendelstrukturVorhanden{
 		"VORHANDEN":       VORHANDEN,
 		"NICHT_VORHANDEN": NICHT_VORHANDEN,
+		"Z31":             VORHANDEN,
+		"Z39":             NICHT_VORHANDEN,
 	}
 
 	_LokationsbuendelstrukturVorhandenValueToName = map[LokationsbuendelstrukturVorhanden]string{
@@ -25,6 +27,8 @@ func init() {
 		_LokationsbuendelstrukturVorhandenNameToValue = map[string]LokationsbuendelstrukturVorhanden{
 			interface{}(VORHANDEN).(fmt.Stringer).String():       VORHANDEN,
 			interface{}(NICHT_VORHANDEN).(fmt.Stringer).String(): NICHT_VORHANDEN,
+			"Z31": VORHANDEN,
+			"Z39": NICHT_VORHANDEN,
 		}
 	}
 }

--- a/market_communication/boney_comb_test.go
+++ b/market_communication/boney_comb_test.go
@@ -242,17 +242,7 @@ func getJsonFilePathsFromSubmodule(dir string) ([]string, error) {
 var formatAllowList = []string{"COMDIS", "INVOIC", "MSCONS", "PRICAT", "QUOTES", "REMADV", "UTILMD"}
 var formatVersionAllowList = []string{"FV2210", "FV2310", "FV2404", "FV2504"}
 
-// skipList contains file name substrings to skip in the submodule test.
-// These files use enum values (e.g. "Z39" for LokationsbuendelstrukturVorhanden)
-// that are not yet supported.
-var skipList = []string{"55175_UTILMD_S2.1_EJEOGPZT7V3059_eog"}
-
 func matchesAllowLists(fileName string) bool {
-	for _, skip := range skipList {
-		if strings.Contains(fileName, skip) {
-			return false
-		}
-	}
 	for _, format := range formatAllowList {
 		if !strings.Contains(fileName, format) {
 			continue


### PR DESCRIPTION
The submodule test file 55175_UTILMD_S2.1_EJEOGPZT7V3059_eog uses the raw EDIFACT qualifier "Z39" for LokationsbuendelstrukturVorhanden instead of the mapped name "NICHT_VORHANDEN". Rather than skipping the file via a skipList workaround, this adds "Z31" and "Z39" as deserialization aliases in the jsonenums map. This is the better approach because:

1. It fixes the root cause instead of masking it
2. Real-world BO4E data may use either EDIFACT codes or mapped names
3. The enum's own docstrings already reference these codes (Z31/Z39)
4. It follows the same alias pattern used for "anderepartei" in Marktteilnehmerrolle