### PR TITLE
feat(json): Omit nil ExtensionData when marshalling

### DIFF
--- a/bo/extension_data_test.go
+++ b/bo/extension_data_test.go
@@ -29,6 +29,23 @@ func TestMarshalBusinessObjectTypesExtensionData(t *testing.T) {
 	}
 }
 
+func TestMarshalBusinessObjectTypesNilExtensionData(t *testing.T) {
+	boTypes := []botyp.BOTyp{
+		botyp.BILANZIERUNG,
+		botyp.LOKATIONSZUORDNUNG,
+		botyp.MARKTLOKATION,
+		botyp.MARKTTEILNEHMER,
+		botyp.MESSLOKATION,
+	}
+
+	for _, boType := range boTypes {
+		t.Run(
+			boType.String(),
+			createMarshalBusinessObjectNilExtensionDataTest(boType),
+		)
+	}
+}
+
 func createMarshalBusinessObjectExtensionDataTest(typ botyp.BOTyp) func(t *testing.T) {
 	return func(t *testing.T) {
 		businessObject := reflect.ValueOf(bo.NewBusinessObject(typ))
@@ -79,6 +96,32 @@ func createMarshalBusinessObjectExtensionDataTest(typ botyp.BOTyp) func(t *testi
 		}
 
 		then.AssertThat(t, dest["extensionField"], is.EqualTo(any("value of extension field")))
+	}
+}
+
+func createMarshalBusinessObjectNilExtensionDataTest(typ botyp.BOTyp) func(t *testing.T) {
+	return func(t *testing.T) {
+		businessObject := reflect.ValueOf(bo.NewBusinessObject(typ))
+		if businessObject.Kind() != reflect.Pointer {
+			t.Fatalf("expected bo.NewBusinessObject() to create pointer")
+		}
+		if businessObject.IsNil() {
+			t.Fatalf("could not create business object for type %s", typ)
+		}
+
+		data, err := json.Marshal(businessObject.Interface())
+		if err != nil {
+			t.Fatalf("could not marshal business object: %+v", err)
+		}
+
+		var dest map[string]any
+		if err := json.Unmarshal(data, &dest); err != nil {
+			t.Fatalf("could not unmarshal back: %+v", err)
+		}
+
+		if _, ok := dest["ExtensionData"]; ok {
+			t.Errorf("did not expect nil extension data to be marshalled as ExtensionData")
+		}
 	}
 }
 

--- a/bo/marktteilnehmer_test.go
+++ b/bo/marktteilnehmer_test.go
@@ -85,7 +85,7 @@ func Test_Marktteilnehmer_Deserialization(t *testing.T) {
 	var deserializedMarktteilnehmer bo.Marktteilnehmer
 	err = json.Unmarshal(serializedMarktteilnehmer, &deserializedMarktteilnehmer)
 	then.AssertThat(t, err, is.Nil())
-	mt.Geschaeftspartner.ExtensionData = unmappeddatamarshaller.ExtensionData{}
+	mt.ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedMarktteilnehmer, is.EqualTo(mt))
 }
 

--- a/bo/marktteilnehmer_test.go
+++ b/bo/marktteilnehmer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/marktrolle"
 	"github.com/hochfrequenz/go-bo4e/enum/rollencodetyp"
 	"github.com/hochfrequenz/go-bo4e/enum/titel"
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 )
 
 // Test_Marktteilnehmer_Deserialization deserializes an Marktteilnehmer json
@@ -84,6 +85,7 @@ func Test_Marktteilnehmer_Deserialization(t *testing.T) {
 	var deserializedMarktteilnehmer bo.Marktteilnehmer
 	err = json.Unmarshal(serializedMarktteilnehmer, &deserializedMarktteilnehmer)
 	then.AssertThat(t, err, is.Nil())
+	mt.Geschaeftspartner.ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedMarktteilnehmer, is.EqualTo(mt))
 }
 

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/waehrungseinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
 	"github.com/hochfrequenz/go-bo4e/internal/testcase"
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
 )
 
@@ -93,6 +94,7 @@ func Test_Preisblatt_Deserialization(t *testing.T) {
 	deserializedPricat.Preispositionen = []com.Preisposition{deserializedPricat.Preispositionen[0]}
 	//deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{deserializedPricat.Preispositionen[0].Preisstaffeln[0]}
 	deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{pricat.Preispositionen[0].Preisstaffeln[0]}
+	pricat.Herausgeber.Geschaeftspartner.ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedPricat, is.EqualTo(pricat))
 }
 

--- a/bo/preisblatt_test.go
+++ b/bo/preisblatt_test.go
@@ -94,7 +94,7 @@ func Test_Preisblatt_Deserialization(t *testing.T) {
 	deserializedPricat.Preispositionen = []com.Preisposition{deserializedPricat.Preispositionen[0]}
 	//deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{deserializedPricat.Preispositionen[0].Preisstaffeln[0]}
 	deserializedPricat.Preispositionen[0].Preisstaffeln = []com.Preisstaffel{pricat.Preispositionen[0].Preisstaffeln[0]}
-	pricat.Herausgeber.Geschaeftspartner.ExtensionData = unmappeddatamarshaller.ExtensionData{}
+	pricat.Herausgeber.ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedPricat, is.EqualTo(pricat))
 }
 

--- a/bo/vertrag_test.go
+++ b/bo/vertrag_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/enum/vertragsart"
 	"github.com/hochfrequenz/go-bo4e/enum/vertragsstatus"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
 )
 
@@ -95,6 +96,7 @@ func Test_Vertrag_Deserialization(t *testing.T) {
 	var deserializedVertrag bo.Vertrag
 	err = json.Unmarshal(serializedContract, &deserializedVertrag)
 	then.AssertThat(t, err, is.Nil())
+	contract.Vertragsteile[0].ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedVertrag, is.EqualTo(contract))
 }
 

--- a/com/vertragsteil_test.go
+++ b/com/vertragsteil_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hochfrequenz/go-bo4e/com"
 	"github.com/hochfrequenz/go-bo4e/enum/mengeneinheit"
 	"github.com/hochfrequenz/go-bo4e/internal"
+	"github.com/hochfrequenz/go-bo4e/internal/unmappeddatamarshaller"
 	"github.com/shopspring/decimal"
 )
 
@@ -42,6 +43,7 @@ func Test_Vertragsteil_Deserialization(t *testing.T) {
 	var deserializedVertragsteil com.Vertragsteil
 	err = json.Unmarshal(serializedVertragsteil, &deserializedVertragsteil)
 	then.AssertThat(t, err, is.Nil())
+	vertraqsteil.ExtensionData = unmappeddatamarshaller.ExtensionData{}
 	then.AssertThat(t, deserializedVertragsteil, is.EqualTo(vertraqsteil))
 }
 

--- a/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
+++ b/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
@@ -39,8 +39,8 @@ func HandleUnmappedDataPropertyMarshalling(b []byte) (bytes []byte, err error) {
 				for k, v := range unmappedDataMap {
 					structFields[k] = v
 				}
-				delete(structFields, fieldName)
 			}
+			delete(structFields, fieldName)
 		}
 	}
 

--- a/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
+++ b/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
@@ -40,8 +40,8 @@ func HandleUnmappedDataPropertyMarshalling(b []byte) (bytes []byte, err error) {
 					structFields[k] = v
 				}
 			}
-            // this is to avoid `"ExtensionData": null` in the json output
-            // which consumers might interpret as unmapped property
+			// this is to avoid `"ExtensionData": null` in the json output
+			// which consumers might interpret as unmapped property
 			delete(structFields, fieldName)
 		}
 	}

--- a/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
+++ b/internal/unmappeddatamarshaller/unmappeddatamarshaller.go
@@ -40,6 +40,8 @@ func HandleUnmappedDataPropertyMarshalling(b []byte) (bytes []byte, err error) {
 					structFields[k] = v
 				}
 			}
+            // this is to avoid `"ExtensionData": null` in the json output
+            // which consumers might interpret as unmapped property
 			delete(structFields, fieldName)
 		}
 	}

--- a/internal/unmappeddatamarshaller/unmappeddatamarshaller_test.go
+++ b/internal/unmappeddatamarshaller/unmappeddatamarshaller_test.go
@@ -82,3 +82,18 @@ func Test_Marshalling_WitUnmappedData_PreservesUnmappedDataInJson(t *testing.T) 
 		t.Errorf("Marshalling struct with unmapped data failed:\nexpected: %s,\nactual: %s", expectedJson, actualJson)
 	}
 }
+
+func Test_Marshalling_WithNilUnmappedData_OmitsExtensionDataFromJson(t *testing.T) {
+	structWithoutUnmappedData := SomeStruct{A: "nice", B: 911}
+
+	actual, err := json.Marshal(structWithoutUnmappedData)
+	if err != nil {
+		t.Errorf("Error occured while marshalling: %v", err)
+	}
+
+	expectedJson := `{"A":"nice","B":911}`
+	actualJson := string(actual)
+	if expectedJson != actualJson {
+		t.Errorf("Marshalling struct with nil unmapped data failed:\nexpected: %s,\nactual: %s", expectedJson, actualJson)
+	}
+}

--- a/internal/unmappeddatamarshaller/unmappeddatamarshaller_test.go
+++ b/internal/unmappeddatamarshaller/unmappeddatamarshaller_test.go
@@ -88,7 +88,7 @@ func Test_Marshalling_WithNilUnmappedData_OmitsExtensionDataFromJson(t *testing.
 
 	actual, err := json.Marshal(structWithoutUnmappedData)
 	if err != nil {
-		t.Errorf("Error occured while marshalling: %v", err)
+		t.Errorf("Error occurred while marshalling: %v", err)
 	}
 
 	expectedJson := `{"A":"nice","B":911}`


### PR DESCRIPTION
## Summary
- omit nil ExtensionData from marshalled JSON instead of emitting ExtensionData: null
- keep non-empty ExtensionData flattened into top-level JSON fields
- add regression coverage at the helper level and across BO types

## Context
A nil ExtensionData map was previously left in the marshalled output as ExtensionData: null. Downstream systems can treat this as a real unmapped property named ExtensionData. Non-empty ExtensionData already flattened correctly; this keeps that behavior and removes the synthetic key for nil maps.